### PR TITLE
Memoize expressions in basic blocks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "files"
 
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog", rev = "a4768b1" }
+egglog = { git = "https://github.com/egraphs-good/egglog", rev = "c83fc75" }
 log = "0.4.19"
 thiserror = "1"
 lalrpop-util = { version = "0.19.8", features = ["lexer"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -239,14 +239,15 @@ impl Optimizer {
         let mut keys = egg_fns.keys().collect::<Vec<&String>>();
         keys.sort();
 
+        let mut termdag = Default::default();
         let mut result = vec![];
         for name in keys {
             let expr = egg_fns.get(name).unwrap();
-            let mut rep = egraph
-                .extract_expr(expr.clone(), 0)
+            let (sort, value) = egraph
+                .eval_expr(expr, None, true)
                 .map_err(EggCCError::EggLog)?;
-            let extracted = rep.termdag.term_to_expr(&rep.expr);
-            let structured_func = self.expr_to_structured_func(extracted);
+            let (_cost, term) = egraph.extract(value, &mut termdag, &sort);
+            let structured_func = self.term_to_structured_func(&termdag, &term);
 
             result.push(structured_func);
         }
@@ -285,7 +286,7 @@ impl Optimizer {
           (lt Type Expr Expr)
           (ptradd Type Expr Expr)
           (load Type Expr)
-        
+
         )
 
         (datatype RetVal

--- a/tests/snapshots/files__add_naiive.snap
+++ b/tests/snapshots/files__add_naiive.snap
@@ -7,8 +7,7 @@ expression: "format!(\"{}\", res)"
   v0: int = const 1;
   v1: int = const 2;
   v2: int = const 3;
-  v0_: int = const 3;
-  print v0_;
+  print v2;
   ret;
 .sblock___0:
 .exit___:

--- a/tests/snapshots/files__add_naiive_no_opt.snap
+++ b/tests/snapshots/files__add_naiive_no_opt.snap
@@ -6,13 +6,8 @@ expression: "format!(\"{}\", res)"
 .entry___:
   v0: int = const 1;
   v1: int = const 2;
-  v0_: int = const 1;
-  v1_: int = const 2;
-  v2: int = add v0_ v1_;
-  v3_: int = const 1;
-  v4_: int = const 2;
-  v2_: int = add v3_ v4_;
-  print v2_;
+  v2: int = add v0 v1;
+  print v2;
   ret;
 .sblock___0:
 .exit___:

--- a/tests/snapshots/files__block-diamond_naiive.snap
+++ b/tests/snapshots/files__block-diamond_naiive.snap
@@ -7,9 +7,7 @@ expression: "format!(\"{}\", res)"
   one: int = const 1;
   two: int = const 2;
   x: int = const 0;
-  v0_: int = const 1;
-  v1_: int = const 2;
-  a_cond: bool = lt v0_ v1_;
+  a_cond: bool = lt one two;
   br a_cond .sblock___4 .sblock___5;
 .sblock___4:
   jmp .sblock___2;

--- a/tests/snapshots/files__block-diamond_naiive_no_opt.snap
+++ b/tests/snapshots/files__block-diamond_naiive_no_opt.snap
@@ -7,9 +7,7 @@ expression: "format!(\"{}\", res)"
   one: int = const 1;
   two: int = const 2;
   x: int = const 0;
-  v0_: int = const 1;
-  v1_: int = const 2;
-  a_cond: bool = lt v0_ v1_;
+  a_cond: bool = lt one two;
   br a_cond .sblock___4 .sblock___5;
 .sblock___4:
   jmp .sblock___2;

--- a/tests/snapshots/files__diamond_naiive.snap
+++ b/tests/snapshots/files__diamond_naiive.snap
@@ -5,9 +5,7 @@ expression: "format!(\"{}\", res)"
 @main {
 .entry___:
   x: int = const 4;
-  v0_: int = const 4;
-  v1_: int = const 4;
-  cond: bool = lt v0_ v1_;
+  cond: bool = lt x x;
   br cond .sblock___3 .sblock___4;
 .sblock___3:
   jmp .sblock___1;

--- a/tests/snapshots/files__diamond_naiive_no_opt.snap
+++ b/tests/snapshots/files__diamond_naiive_no_opt.snap
@@ -5,9 +5,7 @@ expression: "format!(\"{}\", res)"
 @main {
 .entry___:
   x: int = const 4;
-  v0_: int = const 4;
-  v1_: int = const 4;
-  cond: bool = lt v0_ v1_;
+  cond: bool = lt x x;
   br cond .sblock___3 .sblock___4;
 .sblock___3:
   jmp .sblock___1;

--- a/tests/snapshots/files__two_fns_naiive_no_opt.snap
+++ b/tests/snapshots/files__two_fns_naiive_no_opt.snap
@@ -6,9 +6,7 @@ expression: "format!(\"{}\", res)"
 .entry___:
   v0: int = const 1;
   v1: int = const 2;
-  v0_: int = const 1;
-  v1_: int = const 2;
-  v2: int = add v0_ v1_;
+  v2: int = add v0 v1;
   ret;
 .sblock___0:
 .exit___:
@@ -17,9 +15,7 @@ expression: "format!(\"{}\", res)"
 .entry___:
   v0: int = const 1;
   v1: int = const 2;
-  v2_: int = const 1;
-  v3_: int = const 2;
-  v2: int = sub v2_ v3_;
+  v2: int = sub v0 v1;
   ret;
 .sblock___0:
 .exit___:


### PR DESCRIPTION
Quite a bit of refactoring along the way. This PR is a draft until egraphs-good/egglog#207, egraphs-good/egglog#213, and egraphs-good/egglog#214 are merged.

Until then, it's not easy to test this locally, but here's the punchline:

``` text
pub(crate) fn term_to_type(&self, id: &TermId) -> Type {
modified   tests/snapshots/files__add.snap
@@ -10,8 +10,7 @@ expression: "format!(\"{}\", res)"
   v0.0: int = const 1;
   v1.0: int = const 2;
   v2.0: int = const 3;
-  v0_: int = const 3;
-  print v0_;
+  print v2.0;
   ret;
 .sblock___1:
 .exit___:
modified   tests/snapshots/files__add_no_opt.snap
@@ -9,13 +9,8 @@ expression: "format!(\"{}\", res)"
 .b1:
   v0.0: int = const 1;
   v1.0: int = const 2;
-  v0_: int = const 1;
-  v1_: int = const 2;
-  v2.0: int = add v0_ v1_;
-  v3_: int = const 1;
-  v4_: int = const 2;
-  v2_: int = add v3_ v4_;
-  print v2_;
+  v2.0: int = add v0.0 v1.0;
+  print v2.0;
   ret;
 .sblock___1:
 .exit___:
```

We memoize!