### PR TITLE
Initial RVSDG support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,13 @@ log = "0.4.19"
 thiserror = "1"
 lalrpop-util = { version = "0.19.8", features = ["lexer"] }
 petgraph = "0.6"
+hashbrown = "0.14"
+indexmap = "2.0"
+fixedbitset = "0.4.2"
 
 bril2json = { path = "bril/bril-rs/bril2json" }
 brilirs = { path = "bril/brilirs" }
-bril-rs = { path = "bril/bril-rs", features = ["ssa"] }
+bril-rs = { path = "bril/bril-rs" }
 ordered-float = { version = "3.7" }
 serde_json = "1.0.103"
 

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -257,13 +257,7 @@ pub(crate) fn to_cfg(func: &Function) -> Cfg {
     }
     // last block can implicity return, add an edge for that case
     // only if it doesn't already have an outgoing edge
-    if builder
-        .cfg
-        .graph
-        .neighbors_directed(current, petgraph::Outgoing)
-        .next()
-        .is_none()
-    {
+    if !had_branch {
         builder.add_edge(
             current,
             builder.cfg.exit,

--- a/src/cfg/tests.rs
+++ b/src/cfg/tests.rs
@@ -4,7 +4,6 @@ use crate::{
 };
 use bril2json::parse_abstract_program_from_read;
 use bril_rs::{load_program_from_read, Program};
-use petgraph::graph::NodeIndex;
 
 fn parse_from_string(input: &str) -> Program {
     let abs_program = parse_abstract_program_from_read(input.as_bytes(), true, false, None);
@@ -41,9 +40,10 @@ macro_rules! cfg_test {
                 mentioned.insert(to_block!($src));
                 mentioned.insert(to_block!($dst));
             )*
-            for (i, node) in cfg.graph.raw_nodes().iter().enumerate() {
-                assert!(mentioned.contains(&node.weight.name), "description does not mention block {:?}", node.weight.name);
-                block.insert(node.weight.name.clone(), NodeIndex::new(i));
+            for i in cfg.graph.node_indices() {
+                let node = cfg.graph.node_weight(i).unwrap();
+                assert!(mentioned.contains(&node.name), "description does not mention block {:?}", node.name);
+                block.insert(node.name.clone(), i);
             }
             $({
                 let src_name = to_block!($src);
@@ -64,8 +64,8 @@ cfg_test!(
     include_str!("../../tests/fib.bril"),
     [
         ENTRY  = (Jmp) => "loop",
-        "loop" = (Cond { arg: "cond".into(), val: true }) => "body",
-        "loop" = (Cond { arg: "cond".into(), val: false }) => "done",
+        "loop" = (Cond { arg: "cond".into(), val: true.into() }) => "body",
+        "loop" = (Cond { arg: "cond".into(), val: false.into() }) => "done",
         "body" = (Jmp) => "loop",
         "done" = (Jmp) => EXIT,
     ]
@@ -75,16 +75,16 @@ cfg_test!(
     queen,
     include_str!("../../tests/small/queens-func.bril"),
     [
-        ENTRY = (Cond { arg: "ret_cond".into(), val: true }) => "next.ret",
-        ENTRY = (Cond { arg: "ret_cond".into(), val: false }) => "for.cond",
-        "for.cond" = (Cond { arg: "for_cond_0".into(), val: true }) => "for.body",
-        "for.cond" = (Cond { arg: "for_cond_0".into(), val: false }) => "next.ret.1",
-        "for.body" = (Cond { arg: "is_valid".into(), val: true }) => "rec.func",
-        "for.body" = (Cond { arg: "is_valid".into(), val: false }) => "next.loop",
+        ENTRY = (Cond { arg: "ret_cond".into(), val: true.into() }) => "next.ret",
+        ENTRY = (Cond { arg: "ret_cond".into(), val: false.into() }) => "for.cond",
+        "for.cond" = (Cond { arg: "for_cond_0".into(), val: true.into() }) => "for.body",
+        "for.cond" = (Cond { arg: "for_cond_0".into(), val: false.into() }) => "next.ret.1",
+        "for.body" = (Cond { arg: "is_valid".into(), val: true.into() }) => "rec.func",
+        "for.body" = (Cond { arg: "is_valid".into(), val: false.into() }) => "next.loop",
         "rec.func" = (Jmp) => "next.loop",
         "next.loop" = (Jmp) => "for.cond",
-        "next.ret" = (RetVal { arg: "icount".into() }) => EXIT,
-        "next.ret.1" = (RetVal { arg: "icount".into() }) => EXIT,
+        "next.ret" = (Jmp) => EXIT,
+        "next.ret.1" = (Jmp) => EXIT,
     ]
 );
 
@@ -100,8 +100,8 @@ cfg_test!(
     diamond,
     include_str!("../../tests/small/diamond.bril"),
     [
-        ENTRY = (Cond { arg: "cond".into(), val: true }) => "B",
-        ENTRY = (Cond { arg: "cond".into(), val: false }) => "C",
+        ENTRY = (Cond { arg: "cond".into(), val: true.into() }) => "B",
+        ENTRY = (Cond { arg: "cond".into(), val: false.into() }) => "C",
         "B" = (Jmp) => "D",
         "C" = (Jmp) => "D",
         "D" = (Jmp) => EXIT,
@@ -112,10 +112,10 @@ cfg_test!(
     block_diamond,
     include_str!("../../tests/small/block-diamond.bril"),
     [
-        ENTRY = (Cond { arg: "a_cond".into(), val: true }) => "B",
-        ENTRY = (Cond { arg: "a_cond".into(), val: false }) => "D",
-        "B"   = (Cond { arg: "b_cond".into(), val: true}) => "C",
-        "B"   = (Cond { arg: "b_cond".into(), val: false}) => "E",
+        ENTRY = (Cond { arg: "a_cond".into(), val: true.into() }) => "B",
+        ENTRY = (Cond { arg: "a_cond".into(), val: false.into() }) => "D",
+        "B"   = (Cond { arg: "b_cond".into(), val: true.into() }) => "C",
+        "B"   = (Cond { arg: "b_cond".into(), val: false.into() }) => "E",
         "C" = (Jmp) => "F",
         "D" = (Jmp) => "E",
         "E" = (Jmp) => "F",
@@ -127,10 +127,10 @@ cfg_test!(
     unstructured,
     include_str!("../../tests/small/unstructured.bril"),
     [
-        ENTRY = (Cond { arg: "a_cond".into(), val: true }) => "B",
-        ENTRY = (Cond { arg: "a_cond".into(), val: false }) => "C",
-        "B"   = (Cond { arg: "b_cond".into(), val: true }) => "C",
-        "B"   = (Cond { arg: "b_cond".into(), val: false }) => "D",
+        ENTRY = (Cond { arg: "a_cond".into(), val: true.into() }) => "B",
+        ENTRY = (Cond { arg: "a_cond".into(), val: false.into() }) => "C",
+        "B"   = (Cond { arg: "b_cond".into(), val: true.into() }) => "C",
+        "B"   = (Cond { arg: "b_cond".into(), val: false.into() }) => "D",
         "C" = (Jmp) => "B",
         "D" = (Jmp) => EXIT,
     ]
@@ -141,8 +141,8 @@ cfg_test!(
     include_str!("../../tests/small/fib_shape.bril"),
     [
         ENTRY = (Jmp) => "loop",
-        "loop" = (Cond { arg: "cond".into(), val: true }) => "body",
-        "loop" = (Cond { arg: "cond".into(), val: false }) => "done",
+        "loop" = (Cond { arg: "cond".into(), val: true.into() }) => "body",
+        "loop" = (Cond { arg: "cond".into(), val: false.into() }) => "done",
         "body" = (Jmp) => "loop",
         "done" = (Jmp) => EXIT,
     ]

--- a/src/cfg/tests.rs
+++ b/src/cfg/tests.rs
@@ -149,7 +149,7 @@ cfg_test!(
 );
 
 #[test]
-fn unstructured_panics() {
+fn unstructured_causes_error() {
     let func = &parse_from_string(include_str!("../../tests/small/unstructured.bril")).functions[0];
     assert!(matches!(
         to_structured(&to_cfg(func)),

--- a/src/conversions.rs
+++ b/src/conversions.rs
@@ -131,6 +131,7 @@ impl Optimizer {
 
                     BasicBlock {
                         name: BlockName::Named(name.to_string()),
+                        footer: Default::default(),
                         instrs,
                         pos: None,
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,8 +11,9 @@ use std::process::Stdio;
 
 use thiserror::Error;
 
-mod cfg;
+pub(crate) mod cfg;
 mod conversions;
+pub(crate) mod rvsdg;
 mod util;
 use cfg::structured::StructuredProgram;
 

--- a/src/rvsdg/from_cfg.rs
+++ b/src/rvsdg/from_cfg.rs
@@ -1,0 +1,483 @@
+//! Conversion from (structured) CFG to RVSDG.
+//!
+//! This works by running a single pass (inspired by optir) over the
+//! restructured CFG. The core idea is to "symbolically execute" the structured
+//! CFG where unknown values (e.g. those of loop variables, or those of join
+//! points) are replaced with references to either arguments to the enclosing
+//! region or outputs from some region. To detect the start of loop regions, we
+//! look for back-edges dominated by the current node. To detect the start of
+//! branch regions, we look for nodes with more than one successor.
+
+use bril_rs::{ConstOps, EffectOps, Instruction, Literal, Position, Type, ValueOps};
+use hashbrown::HashMap;
+use petgraph::algo::dominators;
+use petgraph::visit::EdgeRef;
+use petgraph::Direction;
+use petgraph::{algo::dominators::Dominators, stable_graph::NodeIndex};
+
+use crate::cfg::{ret_id, Annotation, BranchOp, Cfg, CondVal, Identifier};
+use crate::rvsdg::Result;
+
+use super::live_variables::{live_variables, Names};
+use super::RvsdgFunction;
+use super::{
+    live_variables::{LiveVariableAnalysis, VarId},
+    Expr, Id, Operand, RvsdgBody, RvsdgError,
+};
+
+pub(crate) fn to_rvsdg(cfg: &mut Cfg) -> Result<RvsdgFunction> {
+    cfg.restructure();
+    let analysis = live_variables(cfg);
+    let dom = dominators::simple_fast(&cfg.graph, cfg.entry);
+    let mut builder = RvsdgBuilder {
+        cfg,
+        expr: Default::default(),
+        analysis,
+        dom,
+        store: Default::default(),
+    };
+
+    for (i, arg) in builder.cfg.args.iter().enumerate() {
+        let arg_var = builder.analysis.intern.intern(&arg.name);
+        builder.store.insert(arg_var, Operand::Arg(i));
+    }
+
+    let mut cur = builder.cfg.entry;
+    while let Some(next) = builder.try_loop(cur)? {
+        if next == builder.cfg.exit {
+            break;
+        }
+        cur = next;
+    }
+    let result = if builder.cfg.has_return_value() {
+        let ret_var = builder.analysis.intern.intern(ret_id());
+        Some(get_op(
+            ret_var,
+            &None,
+            &builder.store,
+            &builder.analysis.intern,
+        )?)
+    } else {
+        None
+    };
+    Ok(RvsdgFunction {
+        n_args: builder.cfg.args.len(),
+        nodes: builder.expr,
+        result,
+    })
+}
+
+pub(crate) struct RvsdgBuilder<'a> {
+    cfg: &'a mut Cfg,
+    expr: Vec<RvsdgBody>,
+    analysis: LiveVariableAnalysis,
+    dom: Dominators<NodeIndex>,
+    store: HashMap<VarId, Operand>,
+}
+
+impl<'a> RvsdgBuilder<'a> {
+    fn try_loop(&mut self, block: NodeIndex) -> Result<Option<NodeIndex>> {
+        // First, check if this is the head of a loop. There are two cases here:
+        //
+        // 1. The loop is a single block, in which case this block will have
+        // itself as a neighbor.
+        let is_self_loop = self
+            .cfg
+            .graph
+            .neighbors_directed(block, Direction::Outgoing)
+            .any(|n| n == block);
+        // 2. this is the start of a "do-while" loop. We can check this by seeing
+        // if `block` dominates any of its incoming edges.
+        let loop_tail = if is_self_loop {
+            None
+        } else {
+            self.cfg
+                .graph
+                .neighbors_directed(block, Direction::Incoming)
+                .find(|pred| {
+                    let Some(mut dom) = self.dom.dominators(*pred) else { return false; };
+                    dom.any(|n| n == block)
+                })
+        };
+
+        if !is_self_loop && loop_tail.is_none() {
+            // This is not a loop! Look at the other cases.
+            return self.try_branch(block);
+        }
+
+        // First, we need to record the live operands going into the loop. These
+        // are the loop inputs.
+        let live_vars = self.analysis.var_state(block).unwrap();
+
+        let mut block_params = live_vars.live_in.clone();
+        block_params.merge(&live_vars.live_out);
+
+        let mut inputs = Vec::new();
+        let pos = self.cfg.graph[block].pos.clone();
+        for (i, input) in block_params.iter().enumerate() {
+            // Record the initial value of the loop variable
+            inputs.push(get_op(input, &pos, &self.store, &self.analysis.intern)?);
+            // Mark it as an argument to the loop.
+            self.store.insert(input, Operand::Arg(i));
+        }
+
+        // Now we "run" the loop until we reach the end:
+        let tail = if let Some(tail) = loop_tail {
+            let mut next = self.try_branch(block)?.unwrap();
+            while next != tail {
+                next = self.try_loop(next)?.unwrap();
+            }
+            tail
+        } else {
+            debug_assert!(is_self_loop);
+            block
+        };
+
+        self.translate_block(tail)?;
+
+        let mut outputs = Vec::with_capacity(inputs.len());
+        for input in block_params.iter() {
+            outputs.push(get_op(input, &pos, &self.store, &self.analysis.intern)?);
+        }
+
+        // Now to discover the loop predicate:
+        let branches = Vec::from_iter(
+            self.cfg
+                .graph
+                .edges_connecting(tail, block)
+                .map(|e| e.weight().op.clone()),
+        );
+
+        if branches.len() != 1 {
+            return Err(RvsdgError::UnsupportedLoopTail {
+                pos: self.cfg.graph[tail].pos.clone(),
+            });
+        }
+
+        let pred = match branches.into_iter().next().unwrap() {
+            BranchOp::Jmp
+            | BranchOp::Cond {
+                val: CondVal { of: 1, .. },
+                ..
+            } => {
+                // Predicate is just "true"
+                Operand::Id(get_id(
+                    &mut self.expr,
+                    RvsdgBody::PureOp(Expr::Const(
+                        ConstOps::Const,
+                        Type::Bool,
+                        Literal::Bool(true),
+                    )),
+                ))
+            }
+            BranchOp::Cond {
+                arg,
+                val: CondVal { val, of },
+            } => {
+                assert_eq!(
+                    of, 2,
+                    "loop predicate has more than two options (restructuring should avoid this)"
+                );
+                let var = self.analysis.intern.intern(arg);
+                let op = get_op(var, &None, &self.store, &self.analysis.intern)?;
+                if val == 0 {
+                    // We need to negate the operand
+                    Operand::Id(get_id(
+                        &mut self.expr,
+                        RvsdgBody::PureOp(Expr::Op(ValueOps::Not, vec![op])),
+                    ))
+                } else {
+                    op
+                }
+            }
+        };
+
+        let theta_node = get_id(
+            &mut self.expr,
+            RvsdgBody::Theta {
+                pred,
+                inputs,
+                outputs,
+            },
+        );
+
+        for (i, var) in block_params.iter().enumerate() {
+            self.store.insert(var, Operand::Project(i, theta_node));
+        }
+        Ok(self
+            .cfg
+            .graph
+            .neighbors_directed(tail, Direction::Outgoing)
+            .find(|succ| succ != &block))
+    }
+
+    fn try_branch(&mut self, block: NodeIndex) -> Result<Option<NodeIndex>> {
+        self.translate_block(block)?;
+        if self
+            .cfg
+            .graph
+            .neighbors_directed(block, Direction::Outgoing)
+            .nth(1)
+            .is_none()
+        {
+            // This is a linear region
+            return Ok(self
+                .cfg
+                .graph
+                .neighbors_directed(block, Direction::Outgoing)
+                .next());
+        }
+        let placeholder = Identifier::Num(!0);
+        let mut pred = placeholder.clone();
+        let mut succs = Vec::from_iter(self.cfg.graph.edges_directed(block, Direction::Outgoing).map(|e| {
+            if let BranchOp::Cond { arg, val: CondVal { val, of:_ }} = &e.weight().op {
+                if pred == placeholder {
+                    pred = arg.clone();
+                }
+                (*val, e.target())
+            } else {
+                panic!("Invalid mix of conditional and non-conditional branches in block {block:?}")
+            }
+        }));
+        succs.sort_by_key(|(val, _)| *val);
+        // Branches should be contiguous.
+        succs
+            .iter()
+            .enumerate()
+            .for_each(|(i, (val, _))| assert_eq!(i, *val as usize));
+
+        let mut inputs = Vec::<Operand>::new();
+        let mut outputs = Vec::<Vec<Operand>>::new();
+        let live_vars = self.analysis.var_state(block).unwrap();
+        for var in live_vars.live_in.iter() {
+            inputs.push(get_op(var, &None, &self.store, &self.analysis.intern)?);
+        }
+
+        let mut next = None;
+        for (_, succ) in succs {
+            // First, make sure that all inputs are correctly bound to inputs to the block.
+            let live_vars = self.analysis.var_state(block).unwrap();
+            for (i, var) in live_vars.live_in.iter().enumerate() {
+                self.store.insert(var, Operand::Arg(i));
+            }
+            // Loop until we reach a join point.
+            let mut curr = succ;
+            loop {
+                curr = self.try_loop(curr)?.unwrap();
+                if self
+                    .cfg
+                    .graph
+                    .neighbors_directed(curr, Direction::Incoming)
+                    .nth(1)
+                    .is_some()
+                {
+                    break;
+                }
+            }
+
+            let pos = &self.cfg.graph[curr].pos;
+
+            // Use the join point's live outputs
+            let live_vars = self.analysis.var_state(curr).unwrap();
+            let mut output_vec = Vec::new();
+            for var in live_vars.live_in.iter() {
+                let op = get_op(var, pos, &self.store, &self.analysis.intern)?;
+                output_vec.push(op);
+            }
+            outputs.push(output_vec);
+            if let Some(next) = next {
+                assert_eq!(next, curr);
+            } else {
+                next = Some(curr);
+            }
+        }
+
+        let next = next.unwrap();
+        let pred_var = self.analysis.intern.intern(pred);
+        let pred = get_op(
+            pred_var,
+            &self.cfg.graph[block].pos,
+            &self.store,
+            &self.analysis.intern,
+        )?;
+        let gamma_node = get_id(
+            &mut self.expr,
+            RvsdgBody::Gamma {
+                pred,
+                inputs,
+                outputs,
+            },
+        );
+        // Remap all input variables to the output of this node.
+        for (i, var) in self
+            .analysis
+            .var_state(next)
+            .unwrap()
+            .live_in
+            .iter()
+            .enumerate()
+        {
+            self.store.insert(var, Operand::Project(i, gamma_node));
+        }
+
+        Ok(Some(next))
+    }
+
+    fn translate_block(&mut self, block: NodeIndex) -> Result<()> {
+        let block = &self.cfg.graph[block];
+
+        fn convert_args(
+            args: &[String],
+            analysis: &mut LiveVariableAnalysis,
+            env: &mut HashMap<VarId, Operand>,
+            pos: &Option<Position>,
+        ) -> Result<Vec<Operand>> {
+            let mut ops = Vec::with_capacity(args.len());
+            for arg in args {
+                let arg_var = analysis.intern.intern(arg);
+                let Some(arg_id) = env.get(&arg_var).copied() else {
+                    return Err(RvsdgError::UndefinedId {
+                        id: arg.into(),
+                        pos: pos.clone(),
+                    });
+                };
+                ops.push(arg_id);
+            }
+            Ok(ops)
+        }
+
+        for instr in &block.instrs {
+            match instr {
+                Instruction::Constant {
+                    dest,
+                    op,
+                    const_type,
+                    value,
+                    ..
+                } => {
+                    let dest_var = self.analysis.intern.intern(dest);
+                    let const_id = get_id(
+                        &mut self.expr,
+                        RvsdgBody::PureOp(Expr::Const(*op, const_type.clone(), value.clone())),
+                    );
+                    self.store.insert(dest_var, Operand::Id(const_id));
+                }
+                Instruction::Value {
+                    args,
+                    dest,
+                    funcs,
+                    labels: _,
+                    op,
+                    pos,
+                    op_type: _,
+                } => match op {
+                    ValueOps::Alloc | ValueOps::Load | ValueOps::PtrAdd => {
+                        return Err(RvsdgError::UnsupportedOperation {
+                            op: *op,
+                            pos: pos.clone(),
+                        });
+                    }
+                    ValueOps::Id => {
+                        let dest_var = self.analysis.intern.intern(dest);
+                        let src_var = self.analysis.intern.intern(&args[0]);
+                        let Some(arg_id) = self.store.get(&src_var).copied() else {
+                            return Err(RvsdgError::UndefinedId {
+                                id: self.analysis.intern.get_var(src_var).clone(),
+                                pos: pos.clone(),
+                            });
+                        };
+                        self.store.insert(dest_var, arg_id);
+                    }
+                    _ => {
+                        let dest_var = self.analysis.intern.intern(dest);
+                        let ops = convert_args(args, &mut self.analysis, &mut self.store, pos)?;
+                        let expr = if let ValueOps::Call = op {
+                            Expr::Call((&funcs[0]).into(), ops)
+                        } else {
+                            Expr::Op(*op, ops)
+                        };
+                        let expr_id = get_id(&mut self.expr, RvsdgBody::PureOp(expr));
+                        self.store.insert(dest_var, Operand::Id(expr_id));
+                    }
+                },
+                Instruction::Effect {
+                    op: EffectOps::Nop, ..
+                } => {}
+                Instruction::Effect {
+                    op: EffectOps::Call,
+                    args,
+                    funcs,
+                    pos,
+                    ..
+                } => {
+                    let _ops = convert_args(args, &mut self.analysis, &mut self.store, pos)?;
+                    debug_assert_eq!(funcs.len(), 1);
+                    // For now, there's nothing more to do when calling
+                    // functions that have no return value. Eventually we'll
+                    // need it though!
+                }
+                Instruction::Effect { op, pos, .. } => {
+                    // Two notes here:
+                    // * Control flow like Return and Jmp _are_ supported, but
+                    // the instructions should be eliminated as part of CFG
+                    // conversion and they should instead show up as branches.
+                    //
+                    // * Print isn't supported (yet!) because it would require
+                    // some form of "state" plumbing to ensure it is actually
+                    // run.
+                    return Err(RvsdgError::UnsupportedEffect {
+                        op: *op,
+                        pos: pos.clone(),
+                    });
+                }
+            }
+        }
+
+        for ann in &block.footer {
+            match ann {
+                Annotation::AssignCond { dst, cond } => {
+                    let id = get_id(
+                        &mut self.expr,
+                        RvsdgBody::PureOp(Expr::Const(
+                            ConstOps::Const,
+                            Type::Int,
+                            Literal::Int(*cond as i64),
+                        )),
+                    );
+                    let dest_var = self.analysis.intern.intern(dst.clone());
+                    self.store.insert(dest_var, Operand::Id(id));
+                }
+                Annotation::AssignRet { src } => {
+                    let src_var = self.analysis.intern.intern(src.clone());
+                    let ret_var = self.analysis.intern.intern(ret_id());
+                    self.store.insert(
+                        ret_var,
+                        get_op(src_var, &block.pos, &self.store, &self.analysis.intern)?,
+                    );
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+fn get_id(exprs: &mut Vec<RvsdgBody>, body: RvsdgBody) -> Id {
+    let id = exprs.len();
+    exprs.push(body);
+    id as Id
+}
+
+fn get_op(
+    var: VarId,
+    pos: &Option<Position>,
+    env: &HashMap<VarId, Operand>,
+    intern: &Names,
+) -> Result<Operand> {
+    match env.get(&var) {
+        Some(op) => Ok(*op),
+        None => Err(RvsdgError::UndefinedId {
+            id: intern.get_var(var).clone(),
+            pos: pos.clone(),
+        }),
+    }
+}

--- a/src/rvsdg/live_variables.rs
+++ b/src/rvsdg/live_variables.rs
@@ -1,0 +1,284 @@
+//! Basic live variable analysis for bril programs.
+//!
+//! The structure here follows that of optir, which in turn implements a (less
+//! optimized) variant of the live variable analysis described in "Iterative
+//! Data-flow Analysis, Revisited", by Keith D. Cooper, Timothy J. Harvey, and
+//! Ken Kennedy.
+use std::fmt;
+
+use bril_rs::Instruction;
+use fixedbitset::FixedBitSet;
+use hashbrown::HashMap;
+use indexmap::IndexSet;
+use petgraph::{
+    stable_graph::NodeIndex,
+    visit::{DfsPostOrder, VisitMap, Visitable},
+    Direction,
+};
+
+use crate::{
+    cfg::{ret_id, Annotation, BranchOp, Cfg, CondVal, Identifier, NodeSet},
+    util::ListDisplay,
+};
+
+pub(crate) fn live_variables(cfg: &Cfg) -> LiveVariableAnalysis {
+    let mut analysis = LiveVariableAnalysis::default();
+    let mut names = Names::default();
+    let mut dfs = DfsPostOrder::new(&cfg.graph, cfg.entry);
+    let mut worklist = WorkList::new(cfg);
+    while let Some(block) = dfs.next(&cfg.graph) {
+        let state = analysis.var_state_mut(block);
+        let weight = &cfg.graph[block];
+
+        if block == cfg.exit && cfg.has_return_value() {
+            // The exit block uses the return value, if there is one.
+            state.gen.insert(names.intern(ret_id()));
+        }
+
+        // Live variable analysis is "bottom-up": we do everything in reverse
+        // order. First, look at the branches:
+
+        for edge in cfg.graph.edges_directed(block, Direction::Outgoing) {
+            if let BranchOp::Cond {
+                arg,
+                val: CondVal { val: _, of },
+            } = &edge.weight().op
+            {
+                if *of > 1 {
+                    state.gen.insert(names.intern(arg.clone()));
+                }
+                // of == 1 is an unconditional jump.
+            }
+        }
+
+        // Then the footers (in reverse order; though they shouldn't contain any
+        // mutual dependencies).
+        for ann in weight.footer.iter().rev() {
+            match ann {
+                Annotation::AssignCond { dst, .. } => {
+                    let var = names.intern(dst.clone());
+                    state.kills.insert(var);
+                    state.gen.remove(var);
+                }
+                Annotation::AssignRet { src } => {
+                    state.gen.insert(names.intern(src.clone()));
+                }
+            }
+        }
+
+        // Finally the instructions themselves.
+        for instr in weight.instrs.iter().rev() {
+            match instr {
+                Instruction::Constant { dest, .. } => {
+                    let var = names.intern(dest);
+                    state.kills.insert(var);
+                    state.gen.remove(var);
+                }
+                Instruction::Value { args, dest, .. } => {
+                    let dest = names.intern(dest);
+                    state.kills.insert(dest);
+                    state.gen.remove(dest);
+                    for arg in args {
+                        state.gen.insert(names.intern(arg));
+                    }
+                }
+                Instruction::Effect { args, .. } => {
+                    for arg in args {
+                        state.gen.insert(names.intern(arg));
+                    }
+                }
+            }
+        }
+        worklist.push(block);
+    }
+
+    while let Some(block) = worklist.pop() {
+        let mut changed = false;
+        // Update live_in
+        let state = analysis.var_state_mut(block);
+        changed |= state.live_in.merge(&state.gen);
+        for x in state.live_out.vars.difference(&state.kills.vars) {
+            changed |= state.live_in.insert(VarId(x as u32));
+        }
+
+        // Update live_out
+        for succ in cfg.graph.neighbors(block) {
+            changed |= analysis.union_out_in(block, succ);
+        }
+
+        if changed {
+            cfg.graph
+                .neighbors_directed(block, Direction::Incoming)
+                .for_each(|succ| worklist.push(succ))
+        }
+    }
+
+    analysis.intern = names;
+    analysis
+}
+
+/// An opaque Id representing a variable.
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub(crate) struct VarId(u32);
+
+#[derive(Default, Debug)]
+pub(crate) struct Names {
+    table: IndexSet<Identifier>,
+}
+
+impl Names {
+    pub(crate) fn get_var(&self, id: VarId) -> &Identifier {
+        self.table.get_index(id.0 as usize).unwrap()
+    }
+
+    pub(crate) fn intern(&mut self, name: impl Into<Identifier>) -> VarId {
+        let name = name.into();
+        if let Some(id) = self.table.get_index_of(&name) {
+            return VarId(id as u32);
+        }
+        let id = u32::try_from(self.table.len()).unwrap();
+        self.table.insert(name);
+        VarId(id)
+    }
+}
+
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub(crate) struct VarSet {
+    vars: FixedBitSet,
+}
+
+impl VarSet {
+    pub(crate) fn iter(&self) -> impl Iterator<Item = VarId> + '_ {
+        self.vars.ones().map(|x| VarId(x as u32))
+    }
+    fn insert(&mut self, var: VarId) -> bool {
+        let bit = var.0 as usize;
+        if self.vars.len() <= bit {
+            self.vars.grow(bit + 1);
+        }
+        !self.vars.put(bit)
+    }
+
+    fn remove(&mut self, var: VarId) {
+        let bit = var.0 as usize;
+        if self.vars.len() <= bit {
+            return;
+        }
+        self.vars.set(bit, false);
+    }
+
+    pub(crate) fn merge(&mut self, other: &VarSet) -> bool {
+        if other.vars.is_subset(&self.vars) {
+            return false;
+        }
+        self.vars.union_with(&other.vars);
+        true
+    }
+
+    pub(crate) fn is_subset(&self, other: &VarSet) -> bool {
+        self.vars.is_subset(&other.vars)
+    }
+
+    /// Pretty-print the contents of the variable set with the un-interned
+    /// identifiers given by `names`.
+    pub(crate) fn render(&self, names: &Names) -> String {
+        format!(
+            "{}",
+            ListDisplay(
+                self.iter()
+                    .map(|x| format!("{:?}", names.get_var(x)))
+                    .collect::<Vec<_>>(),
+                ", "
+            )
+        )
+    }
+}
+
+/// The per-basic block state associated with the live variable analysis.
+#[derive(Debug)]
+pub(crate) struct LiveVariableState {
+    /// The variables live on entry to a given basic block.
+    pub(crate) live_in: VarSet,
+    /// The variables live on exit from the basic block.
+    pub(crate) live_out: VarSet,
+    /// The variables written to in the basic block.
+    kills: VarSet,
+    /// The variables used before they are written to in the basic block.
+    gen: VarSet,
+}
+
+#[derive(Default)]
+pub(crate) struct LiveVariableAnalysis {
+    pub(crate) intern: Names,
+    analysis: HashMap<NodeIndex, LiveVariableState>,
+}
+
+impl fmt::Debug for LiveVariableAnalysis {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut map = f.debug_map();
+        for (node, state) in &self.analysis {
+            map.entry(
+                &node.index(),
+                &format!(
+                    "State {{ in: {}, out: {} }}",
+                    state.live_in.render(&self.intern),
+                    state.live_out.render(&self.intern)
+                ),
+            );
+        }
+        map.finish()?;
+        Ok(())
+    }
+}
+
+impl LiveVariableAnalysis {
+    fn var_state_mut(&mut self, node: NodeIndex) -> &mut LiveVariableState {
+        self.analysis.entry(node).or_insert_with(|| {
+            let var_set = VarSet {
+                vars: FixedBitSet::with_capacity(self.intern.table.len()),
+            };
+            LiveVariableState {
+                live_in: var_set.clone(),
+                live_out: var_set.clone(),
+                kills: var_set.clone(),
+                gen: var_set,
+            }
+        })
+    }
+
+    pub(crate) fn var_state(&self, node: NodeIndex) -> Option<&LiveVariableState> {
+        self.analysis.get(&node)
+    }
+
+    /// Union pred's `live_out` set with succ's `live_in` set.
+    fn union_out_in(&mut self, pred: NodeIndex, succ: NodeIndex) -> bool {
+        let Some([pred_state, succ_state]) = self.analysis.get_many_mut([&pred, &succ]) else { return false; };
+        pred_state.live_out.merge(&succ_state.live_in)
+    }
+}
+
+struct WorkList {
+    node_set: NodeSet,
+    stack: Vec<NodeIndex>,
+}
+
+impl WorkList {
+    fn new(cfg: &Cfg) -> WorkList {
+        WorkList {
+            node_set: cfg.graph.visit_map(),
+            stack: Default::default(),
+        }
+    }
+
+    fn push(&mut self, node: NodeIndex) {
+        if !self.node_set.is_visited(&node) {
+            self.stack.push(node);
+        }
+    }
+
+    fn pop(&mut self) -> Option<NodeIndex> {
+        let res = self.stack.pop()?;
+        self.node_set.set(res.index(), false);
+        Some(res)
+    }
+}

--- a/src/rvsdg/mod.rs
+++ b/src/rvsdg/mod.rs
@@ -1,0 +1,140 @@
+#![allow(dead_code)] // TODO: remove this once wired in
+//! Convert bril programs to RVSDGs.
+//!
+//! Bril functions are written in terms of basic blocks and jumps/gotos. RVSDGs
+//! only support intra-function control flow in the form of switch statements
+//! and do-while loops (gamma and theta nodes, respectively). Transforming the
+//! native Bril representation to RVSDGs requires the following steps:
+//!
+//! * Parse to CFG: read the bril program into a graph data-structure where
+//! basic blocks are nodes and edges are jumps. (This happens in the `cfg`
+//! module).
+//!
+//! * Restructure the CFG: Bril programs support irreducible CFGs, but the CFGs
+//! corresponding to RVSDGs are all reducible. Before we convert the CFG to an
+//! RVSDG, we must convert the unstructured CFG to a structured one.
+//!
+//! * RVSDG conversion: Once we have a structured CFG we can convert the
+//! program (still written in terms of gotos) to the structured format for
+//! RVSDGs. Part of this conversion process is the discovery of what the
+//! "inputs" and "outputs" are for different RVSDG nodes; the main subroutine we
+//! use there is a live variable analysis.
+//!
+//! # References
+//!
+//! * ["RVSDG: An Intermediate Representation for Optimizing Compilers"](https://arxiv.org/abs/1912.05036)
+//! by Reissmann, Meyer, Bahmann, and Själander
+//! * ["Perfect Reconstructability of Control Flow from Demand Dependence Graphs"](https://dl.acm.org/doi/10.1145/2693261)
+//! by Bahmann, Reissmann,  Jahre, and Meyer
+//!
+//! In addition to those papers, the Jamey Sharp's
+//! [optir](https://github.com/jameysharp/optir) project is a major inspiration.
+pub(crate) mod from_cfg;
+pub(crate) mod live_variables;
+pub(crate) mod restructure;
+pub(crate) mod rvsdg2svg;
+
+use std::fmt;
+
+use bril_rs::{ConstOps, Literal, Type, ValueOps};
+use thiserror::Error;
+
+use crate::cfg::Identifier;
+
+#[cfg(test)]
+mod tests;
+
+/// Errors from the rvsdg module.
+#[derive(Debug, Error)]
+pub(crate) enum RvsdgError {
+    #[error("Unsupported operation: {op:?}, {pos:?}")]
+    UnsupportedOperation {
+        op: bril_rs::ValueOps,
+        pos: Option<bril_rs::Position>,
+    },
+
+    #[error("Unsupported effect: {op:?}, {pos:?}")]
+    UnsupportedEffect {
+        op: bril_rs::EffectOps,
+        pos: Option<bril_rs::Position>,
+    },
+
+    #[error("Scope error: undefined id {id:?}, {pos:?}")]
+    UndefinedId {
+        id: Identifier,
+        pos: Option<bril_rs::Position>,
+    },
+
+    // NB: We should  be able to suppor these patterns, but it might be better
+    // to desugar them away as part of the CFG parsing step.
+    #[error("Multiple branches from loop tail to head ({pos:?})")]
+    UnsupportedLoopTail { pos: Option<bril_rs::Position> },
+}
+
+pub(crate) type Result<T = ()> = std::result::Result<T, RvsdgError>;
+
+#[derive(Debug)]
+pub(crate) enum Annotation {
+    AssignCond { dst: Identifier, cond: u32 },
+    AssignRet { src: Identifier },
+}
+
+pub(crate) type Id = usize;
+
+#[derive(Debug)]
+pub(crate) enum Expr {
+    Op(ValueOps, Vec<Operand>),
+    Call(Identifier, Vec<Operand>),
+    Const(ConstOps, Type, Literal),
+}
+
+#[derive(Copy, Clone, PartialEq, Eq, Hash, Debug)]
+pub(crate) enum Operand {
+    /// A reference to an argument in the enclosing region.
+    Arg(usize),
+    /// Another node in the RVSDG.
+    Id(Id),
+    /// Project a single output from a multi-output region.
+    Project(usize, Id),
+}
+
+#[derive(Debug)]
+pub(crate) enum RvsdgBody {
+    PureOp(Expr),
+    Gamma {
+        pred: Operand,
+        inputs: Vec<Operand>,
+        outputs: Vec<Vec<Operand>>,
+    },
+    Theta {
+        pred: Operand,
+        inputs: Vec<Operand>,
+        outputs: Vec<Operand>,
+    },
+}
+
+pub(crate) struct RvsdgFunction {
+    /// The number of input arguments to the function.
+    pub(crate) n_args: usize,
+    /// The backing heap for Rvsdg node ids within this function.
+    pub(crate) nodes: Vec<RvsdgBody>,
+    /// The (optional) result pointing into this function.
+    ///
+    /// NB: until effects are supported, the only way to ensure a computation is
+    /// marked as used is to populate a result of some kind.
+    pub(crate) result: Option<Operand>,
+}
+
+impl fmt::Debug for RvsdgFunction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("RvsdgFunction")
+            .field("n_args", &self.n_args)
+            .field("result", &self.result);
+        let mut map = f.debug_map();
+        for (i, node) in self.nodes.iter().enumerate() {
+            map.entry(&i, node);
+        }
+        map.finish()?;
+        write!(f, "}}")
+    }
+}

--- a/src/rvsdg/restructure.rs
+++ b/src/rvsdg/restructure.rs
@@ -1,0 +1,385 @@
+//! Convert a potentially irreducible CFG to a reducible one.
+
+use hashbrown::{HashMap, HashSet};
+use petgraph::{
+    algo::{dominators, tarjan_scc},
+    graph::NodeIndex,
+    stable_graph::EdgeIndex,
+    visit::{EdgeRef, NodeFiltered, VisitMap},
+    Direction,
+};
+
+use crate::cfg::{
+    Annotation, BasicBlock, BlockName, Branch, BranchOp, Cfg, CondVal, Identifier, NodeSet,
+};
+
+fn node_set(nodes: impl IntoIterator<Item = NodeIndex>) -> NodeSet {
+    let mut set = NodeSet::default();
+    for node in nodes {
+        if set.len() <= node.index() {
+            set.grow(node.index() + 1);
+        }
+        set.visit(node);
+    }
+    set
+}
+
+struct RestructureState {
+    n_names: usize,
+}
+
+impl RestructureState {
+    fn fresh(&mut self) -> Identifier {
+        let n = self.n_names;
+        self.n_names += 1;
+        Identifier::Num(n)
+    }
+}
+
+impl Cfg {
+    fn fresh_block(&mut self) -> NodeIndex {
+        let placeholder = self.graph.node_count();
+        self.graph
+            .add_node(BasicBlock::empty(BlockName::Placeholder(placeholder)))
+    }
+
+    pub(crate) fn restructure(&mut self) {
+        let mut state = RestructureState { n_names: 0 };
+        let mut all = NodeSet::with_capacity(self.graph.node_count());
+        self.graph.node_indices().for_each(|node| {
+            all.visit(node);
+        });
+        self.restructure_loops(&all, &mut state);
+        self.restructure_branches(&mut state);
+    }
+
+    fn branch_if(
+        &mut self,
+        from: NodeIndex,
+        to: NodeIndex,
+        id: &Identifier,
+        cv: CondVal,
+    ) -> EdgeIndex {
+        self.graph.add_edge(
+            from,
+            to,
+            Branch {
+                op: BranchOp::Cond {
+                    arg: id.clone(),
+                    val: cv,
+                },
+                pos: None,
+            },
+        )
+    }
+
+    fn rewrite_arcs(
+        &mut self,
+        arcs: impl Iterator<Item = EdgeIndex>,
+        mut annotate: impl FnMut(NodeIndex, &mut Vec<Annotation>) -> NodeIndex,
+    ) {
+        for edge_id in arcs {
+            let (src, target) = self.graph.edge_endpoints(edge_id).unwrap();
+            let branch = self.graph.remove_edge(edge_id).unwrap();
+            match &branch.op {
+                BranchOp::Jmp
+                | BranchOp::Cond {
+                    val: CondVal { val: 0, of: 1 },
+                    ..
+                } => {
+                    // For unconditional jumps, simply annotate the
+                    // source block and reroute the edge
+                    let new_target = annotate(target, &mut self.graph[src].footer);
+                    self.graph.add_edge(src, new_target, branch);
+                }
+                BranchOp::Cond { .. } => {
+                    // For conditional jumps, create a new node and
+                    // route flow through it before jumping to the entry
+                    // node.
+                    let intermediate = self.fresh_block();
+                    let new_target = annotate(target, &mut self.graph[intermediate].footer);
+                    self.graph.add_edge(src, intermediate, branch);
+                    self.graph.add_edge(intermediate, new_target, JMP);
+                }
+            }
+        }
+    }
+
+    fn restructure_loops(&mut self, filter: &NodeSet, state: &mut RestructureState) {
+        let base = NodeFiltered::from_fn(&self.graph, |node| filter.is_visited(&node));
+        let sccs = tarjan_scc(&base);
+        for scc in sccs {
+            if scc.len() < 2 {
+                // Any SCC with this few nodes must be structured.
+                continue;
+            }
+
+            // The following follows the paper fairly literally.
+
+            let scc_set = node_set(scc.iter().copied());
+            let mut entry_arcs = HashSet::new();
+            let mut entry_vertices = HashSet::new();
+            for edge_ref in scc
+                .iter()
+                .flat_map(|node| self.graph.edges_directed(*node, Direction::Incoming))
+                .filter(|e| !scc_set.is_visited(&e.source()))
+            {
+                entry_arcs.insert(edge_ref.id());
+                entry_vertices.insert(edge_ref.target());
+            }
+
+            let mut exit_arcs = HashSet::new();
+            let mut exit_vertices = HashSet::new();
+
+            for edge_ref in scc
+                .iter()
+                .flat_map(|node| self.graph.edges_directed(*node, Direction::Outgoing))
+                .filter(|e| !scc_set.is_visited(&e.target()))
+            {
+                exit_arcs.insert(edge_ref.id());
+                exit_vertices.insert(edge_ref.target());
+            }
+
+            let repetition_arcs: HashSet<EdgeIndex> = entry_vertices
+                .iter()
+                .flat_map(|node| self.graph.edges_directed(*node, Direction::Incoming))
+                .filter(|e| scc_set.is_visited(&e.source()))
+                .map(|e| e.id())
+                .collect();
+
+            let entry_node = if entry_vertices.len() == 1 {
+                *entry_vertices.iter().next().unwrap()
+            } else {
+                self.fresh_block()
+            };
+
+            let exit_node = if exit_vertices.len() == 1 {
+                *exit_vertices.iter().next().unwrap()
+            } else {
+                self.fresh_block()
+            };
+
+            let rep_id = state.fresh();
+            let loop_tail = if !repetition_arcs.is_empty() {
+                let tail_node = self.fresh_block();
+                self.branch_if(tail_node, exit_node, &rep_id, CondVal { val: 0, of: 2 });
+                self.branch_if(tail_node, entry_node, &rep_id, CondVal { val: 1, of: 2 });
+                tail_node
+            } else {
+                exit_node
+            };
+
+            // demux through the entry block.
+            let (block_map, cond_id) =
+                self.make_demux_node(entry_node, entry_vertices.iter().copied(), state);
+
+            self.rewrite_arcs(entry_arcs.iter().copied(), |target, anns| {
+                anns.push(Annotation::AssignCond {
+                    dst: cond_id.clone(),
+                    cond: block_map[&target],
+                });
+                entry_node
+            });
+
+            self.rewrite_arcs(repetition_arcs.iter().copied(), |target, anns| {
+                anns.push(Annotation::AssignCond {
+                    dst: cond_id.clone(),
+                    cond: block_map[&target],
+                });
+                anns.push(Annotation::AssignCond {
+                    dst: rep_id.clone(),
+                    cond: 1,
+                });
+                loop_tail
+            });
+
+            // Now demux exit paths through the exit node:
+
+            let (block_map, cond_id) =
+                self.make_demux_node(exit_node, exit_vertices.iter().copied(), state);
+
+            self.rewrite_arcs(exit_arcs.iter().copied(), |target, anns| {
+                anns.push(Annotation::AssignCond {
+                    dst: cond_id.clone(),
+                    cond: block_map[&target],
+                });
+                anns.push(Annotation::AssignCond {
+                    dst: rep_id.clone(),
+                    cond: 0,
+                });
+                loop_tail
+            });
+
+            if exit_arcs.is_empty() {
+                // Infinite loop
+                self.graph.remove_node(exit_node);
+            }
+
+            // Recursively restructure the inner loop.
+            self.restructure_loops(&scc_set, state);
+        }
+    }
+
+    fn split_arc(&mut self, edge: EdgeIndex) {
+        let (src, dst) = self.graph.edge_endpoints(edge).unwrap();
+        let middle = self.fresh_block();
+        let weight = self.graph.remove_edge(edge).unwrap();
+        self.graph.add_edge(src, middle, weight);
+        self.graph.add_edge(
+            middle,
+            dst,
+            Branch {
+                op: BranchOp::Jmp,
+                pos: None,
+            },
+        );
+    }
+
+    fn split_edges(&mut self, node: NodeIndex) {
+        let mut has_jmp = false;
+        let mut walker = self
+            .graph
+            .neighbors_directed(node, Direction::Outgoing)
+            .detach();
+        while let Some((edge, other)) = walker.next(&self.graph) {
+            assert!(!has_jmp);
+            match &self.graph.edge_weight(edge).unwrap().op {
+                BranchOp::Jmp
+                | BranchOp::Cond {
+                    val: CondVal { of: 1, .. },
+                    ..
+                } => {
+                    has_jmp = true;
+                    continue;
+                }
+                BranchOp::Cond { .. } => {}
+            }
+
+            // We have a conditional branch. Reroute through a placeholder.
+            let weight = self.graph.remove_edge(edge).unwrap();
+            let placeholder = self.fresh_block();
+
+            // We had  node => other
+            // We want node => placeholder => other
+            assert_ne!(other, self.entry);
+            self.graph.add_edge(node, placeholder, weight);
+            self.graph.add_edge(placeholder, other, JMP);
+        }
+    }
+
+    fn make_demux_node(
+        &mut self,
+        node: NodeIndex,
+        targets: impl IntoIterator<Item = NodeIndex>,
+        state: &mut RestructureState,
+    ) -> (HashMap<NodeIndex, u32>, Identifier) {
+        let mut blocks = HashMap::new();
+        for node in targets {
+            let cur_len = u32::try_from(blocks.len()).unwrap();
+            blocks.entry(node).or_insert(cur_len);
+        }
+        let cond = state.fresh();
+
+        let n_blocks = u32::try_from(blocks.len()).unwrap();
+        for (block, val) in blocks.iter() {
+            if *block == node {
+                continue;
+            }
+            self.branch_if(
+                node,
+                *block,
+                &cond,
+                CondVal {
+                    val: *val,
+                    of: n_blocks,
+                },
+            );
+        }
+        (blocks, cond)
+    }
+
+    fn restructure_branches(&mut self, state: &mut RestructureState) {
+        // Credit to optir for structuring the loop in this way; this is pretty different than the paper.
+        let dom = dominators::simple_fast(&self.graph, self.entry);
+        let dominates = |x: NodeIndex, y| {
+            dom.dominators(y)
+                .map(|mut ds| ds.any(|d| x == d))
+                .unwrap_or(false)
+        };
+
+        // The "Perfect Reconstructability" paper uses "continuation point" to
+        // refer to the targets of a branch _not_ part of a structured region.
+        //
+        // We want to group these continuations by their immediate dominators
+        // (called the "Head" in the paper), then add a mux node in front of the
+        // continuations if there is more than one.
+
+        let mut tail_continuations = HashMap::<NodeIndex, Vec<NodeIndex>>::new();
+
+        for ix in self.graph.node_indices() {
+            if let Some(idom) = dom.immediate_dominator(ix) {
+                // Continuations have more than one non-loop incoming edge
+                if self
+                    .graph
+                    .neighbors_directed(ix, Direction::Incoming)
+                    .filter(|pred| !dominates(ix, *pred))
+                    .nth(1)
+                    .is_some()
+                {
+                    tail_continuations.entry(idom).or_default().push(ix);
+                }
+            }
+        }
+
+        for (idom, conts) in tail_continuations.into_iter() {
+            // Split any direct edges from the idom to the continuation. If we
+            // have more than one continuation then split _all_ edges.
+            for cont in &conts {
+                let mut walker = self
+                    .graph
+                    .neighbors_directed(*cont, Direction::Incoming)
+                    .detach();
+                while let Some((e, src)) = walker.next(&self.graph) {
+                    if src == idom && conts.len() == 1 {
+                        self.split_arc(e);
+                    } else if conts.len() > 1 {
+                        self.split_edges(src);
+                    }
+                }
+            }
+
+            // The rest of this loop is focused on mux/demux for multiple
+            // continuations. If we only have one, we are done.
+            if conts.len() == 1 {
+                continue;
+            }
+            let mux = self.fresh_block();
+            let (preds, cond_var) = self.make_demux_node(mux, conts.iter().copied(), state);
+
+            for cont in &conts {
+                let mut walker = self
+                    .graph
+                    .neighbors_directed(*cont, Direction::Incoming)
+                    .detach();
+
+                // NB: there's some extra filtering that happens here in optir, do we need it?
+                while let Some((edge, src)) = walker.next(&self.graph) {
+                    if src == mux {
+                        continue;
+                    }
+                    let branch = self.graph.remove_edge(edge).unwrap();
+                    self.graph.add_edge(src, mux, branch);
+                    self.graph[src].footer.push(Annotation::AssignCond {
+                        dst: cond_var.clone(),
+                        cond: preds[cont],
+                    });
+                }
+            }
+        }
+    }
+}
+
+const JMP: Branch = Branch {
+    op: BranchOp::Jmp,
+    pos: None,
+};

--- a/src/rvsdg/rvsdg2svg.rs
+++ b/src/rvsdg/rvsdg2svg.rs
@@ -1,0 +1,763 @@
+use std::collections::{BTreeMap, BTreeSet};
+use std::iter::once;
+
+use bril_rs::ConstOps;
+
+use crate::cfg::Identifier;
+
+use super::{Expr, Id, Operand, RvsdgBody, RvsdgFunction};
+
+const SIMPLE_NODE_SIZE: f32 = 100.0;
+const STROKE_WIDTH: f32 = SIMPLE_NODE_SIZE * 0.02;
+const NODE_SPACING: f32 = SIMPLE_NODE_SIZE * 0.5;
+const FONT_SIZE: f32 = SIMPLE_NODE_SIZE * 0.5;
+const PORT_RADIUS: f32 = STROKE_WIDTH * 2.0;
+const CORNER_RADIUS: f32 = NODE_SPACING * 0.2;
+const REGION_SPACING: f32 = NODE_SPACING * 0.5;
+
+#[derive(Debug)]
+struct Region {
+    srcs: usize,
+    dsts: usize,
+    nodes: BTreeMap<Id, Node>,
+    edges: Vec<Edge>,
+}
+
+#[derive(Debug)]
+enum Node {
+    Unit(String, usize, usize),
+    Match(Vec<(String, Region)>), // vec must be nonempty
+    Loop(Region),
+}
+
+// Each edge goes from an output port to an input port.
+// `None` refers to the region, `Some(i)` refers to the node at index `i`.
+// The second number is the index of the port that is being referred to.
+type Edge = ((Option<Id>, usize), (Option<Id>, usize));
+
+struct Size {
+    width: f32,
+    height: f32,
+}
+
+struct Xml {
+    tag: String,
+    attributes: BTreeMap<String, String>,
+    body: String,
+}
+
+impl Xml {
+    fn new<'a>(
+        tag: &str,
+        attributes: impl IntoIterator<Item = (&'a str, &'a str)>,
+        body: &str,
+    ) -> Xml {
+        Xml {
+            tag: tag.to_owned(),
+            attributes: attributes
+                .into_iter()
+                .map(|(k, v)| (k.to_owned(), v.to_owned()))
+                .collect(),
+            body: body.to_owned(),
+        }
+    }
+
+    fn group(children: impl IntoIterator<Item = Xml>) -> Xml {
+        Xml {
+            tag: "g".to_owned(),
+            attributes: BTreeMap::new(),
+            body: children.into_iter().map(|xml| xml.to_string()).collect(),
+        }
+    }
+}
+
+impl ToString for Xml {
+    fn to_string(self: &Xml) -> String {
+        use std::fmt::Write;
+        let mut out = String::new();
+
+        write!(out, "<{}", self.tag).unwrap();
+        for (key, value) in &self.attributes {
+            write!(out, "\n\t{key}=\"{value}\"").unwrap();
+        }
+        writeln!(out, ">").unwrap();
+        for line in self.body.lines() {
+            writeln!(out, "\t{line}").unwrap();
+        }
+        writeln!(out, "</{}>", self.tag).unwrap();
+
+        out
+    }
+}
+
+fn blend(width: f32, total: usize, index: usize) -> f32 {
+    width / ((total + 1) as f32) * (index + 1) as f32
+}
+
+impl Node {
+    fn inputs(&self, width: f32) -> Vec<f32> {
+        match self {
+            Node::Unit(_, inputs, _) => (0..*inputs).map(|p| blend(width, *inputs, p)).collect(),
+            Node::Match(branches) => {
+                let inputs = 1 + branches[0].1.srcs;
+                (0..inputs).map(|p| blend(width, inputs, p)).collect()
+            }
+            Node::Loop(region) => (0..region.srcs)
+                .map(|p| REGION_SPACING + blend(width - REGION_SPACING * 2.0, region.srcs, p))
+                .collect(),
+        }
+    }
+
+    fn outputs(&self, width: f32) -> Vec<f32> {
+        match self {
+            Node::Unit(_, _, outputs) => (0..*outputs).map(|p| blend(width, *outputs, p)).collect(),
+            Node::Match(branches) => (0..branches[0].1.dsts)
+                .map(|p| blend(width, branches[0].1.dsts, p))
+                .collect(),
+            Node::Loop(region) => (1..region.dsts)
+                .map(|p| REGION_SPACING + blend(width - REGION_SPACING * 2.0, region.dsts, p))
+                .collect(),
+        }
+    }
+}
+
+fn port(x: f32, y: f32, color: &str) -> Xml {
+    Xml::new(
+        "circle",
+        [
+            ("fill", color),
+            ("stroke", "black"),
+            ("stroke-width", &format!("{}", STROKE_WIDTH)),
+            ("r", &format!("{}", PORT_RADIUS)),
+            ("cx", &format!("{}", x)),
+            ("cy", &format!("{}", y)),
+        ],
+        "",
+    )
+}
+
+impl Node {
+    fn to_xml(&self) -> (Size, Xml) {
+        match self {
+            Node::Unit(text, _, _) => {
+                let size = Size {
+                    width: SIMPLE_NODE_SIZE,
+                    height: SIMPLE_NODE_SIZE,
+                };
+                let node = Xml::group([
+                    Xml::new(
+                        "rect",
+                        [
+                            ("fill", "#FFFF80"),
+                            ("stroke", "black"),
+                            ("width", &format!("{}", SIMPLE_NODE_SIZE)),
+                            ("height", &format!("{}", SIMPLE_NODE_SIZE)),
+                            ("stroke-width", &format!("{}", STROKE_WIDTH)),
+                            ("rx", &format!("{}", CORNER_RADIUS)),
+                        ],
+                        "",
+                    ),
+                    Xml::new(
+                        "text",
+                        [
+                            ("text-anchor", "middle"),
+                            ("fill", "black"),
+                            ("x", &format!("{}", SIMPLE_NODE_SIZE * 0.5)),
+                            ("y", &format!("{}", FONT_SIZE * 1.25)),
+                            ("font-size", &format!("{}", FONT_SIZE)),
+                        ],
+                        text,
+                    ),
+                ]);
+                let inputs = self
+                    .inputs(size.width)
+                    .into_iter()
+                    .map(|x| port(x, 0.0, "white"));
+                let outputs = self
+                    .outputs(size.width)
+                    .into_iter()
+                    .map(|x| port(x, size.height, "white"));
+                let group = Xml::group(once(node).chain(inputs).chain(outputs));
+                (size, group)
+            }
+            Node::Match(branches) => {
+                let children: Vec<_> = branches.iter().map(|t| t.1.to_xml(false)).collect();
+                let size = Size {
+                    width: REGION_SPACING * (children.len() + 1) as f32
+                        + children.iter().map(|t| t.0.width).sum::<f32>(),
+                    height: FONT_SIZE * 2.0
+                        + REGION_SPACING * 2.0
+                        + children
+                            .iter()
+                            .map(|t| t.0.height)
+                            .max_by(f32::total_cmp)
+                            .unwrap_or(0.0),
+                };
+
+                let background = Xml::new(
+                    "rect",
+                    [
+                        ("fill", "#80FF80"),
+                        ("stroke", "black"),
+                        ("width", &format!("{}", size.width)),
+                        ("height", &format!("{}", size.height)),
+                        ("stroke-width", &format!("{}", STROKE_WIDTH)),
+                        ("rx", &format!("{}", CORNER_RADIUS)),
+                    ],
+                    "",
+                );
+                let text = Xml::new(
+                    "text",
+                    [
+                        ("fill", "black"),
+                        ("x", &format!("{}", REGION_SPACING)),
+                        ("y", &format!("{}", FONT_SIZE)),
+                        ("font-size", &format!("{}", FONT_SIZE)),
+                    ],
+                    "match",
+                );
+
+                let mut w = 0.0;
+                let positions: Vec<(f32, f32)> = children
+                    .iter()
+                    .map(|(s, _)| {
+                        w += s.width + REGION_SPACING;
+                        (w - s.width, REGION_SPACING + FONT_SIZE * 2.0)
+                    })
+                    .collect();
+                assert_eq!(w + REGION_SPACING, size.width);
+
+                let branches = positions.iter().zip(children).zip(branches).map(
+                    |(((x, y), (s, mut xml)), (label, _))| {
+                        xml.attributes
+                            .insert("transform".to_owned(), format!("translate({x}, {y})"));
+                        let label = Xml::new(
+                            "text",
+                            [
+                                ("text-anchor", "middle"),
+                                ("fill", "black"),
+                                ("x", &format!("{}", x + s.width * 0.5)),
+                                ("y", &format!("{}", FONT_SIZE * 2.0)),
+                                ("font-size", &format!("{}", FONT_SIZE)),
+                            ],
+                            label,
+                        );
+                        Xml::group([xml, label])
+                    },
+                );
+
+                let c = |p| match p == 0 {
+                    true => "black",
+                    false => "white",
+                };
+                let inputs = self
+                    .inputs(size.width)
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, x)| port(x, 0.0, c(i)));
+                let outputs = self
+                    .outputs(size.width)
+                    .into_iter()
+                    .map(|x| port(x, size.height, "white"));
+                let group = Xml::group(
+                    vec![background, text]
+                        .into_iter()
+                        .chain(branches)
+                        .chain(inputs)
+                        .chain(outputs),
+                );
+                (size, group)
+            }
+            Node::Loop(region) => {
+                let (s, mut xml) = region.to_xml(true);
+                let size = Size {
+                    width: s.width + REGION_SPACING * 2.0,
+                    height: s.height + FONT_SIZE + REGION_SPACING * 2.0,
+                };
+
+                let background = Xml::new(
+                    "rect",
+                    [
+                        ("fill", "#FF8080"),
+                        ("stroke", "black"),
+                        ("width", &format!("{}", size.width)),
+                        ("height", &format!("{}", size.height)),
+                        ("stroke-width", &format!("{}", STROKE_WIDTH)),
+                        ("rx", &format!("{}", CORNER_RADIUS)),
+                    ],
+                    "",
+                );
+                let text = Xml::new(
+                    "text",
+                    [
+                        ("fill", "black"),
+                        ("x", &format!("{}", REGION_SPACING)),
+                        ("y", &format!("{}", FONT_SIZE)),
+                        ("font-size", &format!("{}", FONT_SIZE)),
+                    ],
+                    "loop",
+                );
+
+                let (x, y) = (REGION_SPACING, REGION_SPACING + FONT_SIZE);
+                xml.attributes
+                    .insert("transform".to_owned(), format!("translate({x}, {y})"));
+
+                let inputs = self
+                    .inputs(size.width)
+                    .into_iter()
+                    .map(|x| port(x, 0.0, "white"));
+                let outputs = self
+                    .outputs(size.width)
+                    .into_iter()
+                    .map(|x| port(x, size.height, "white"));
+                let group = Xml::group(
+                    vec![background, text, xml]
+                        .into_iter()
+                        .chain(inputs)
+                        .chain(outputs),
+                );
+                (size, group)
+            }
+        }
+    }
+}
+
+impl Region {
+    fn to_xml(&self, in_loop: bool) -> (Size, Xml) {
+        let mut edges = self.edges.clone();
+        edges.sort();
+
+        let mut children: BTreeMap<_, _> = self.nodes.iter().map(|t| (t.0, t.1.to_xml())).collect();
+
+        let mut layers: Vec<Vec<Id>> = vec![];
+        let mut to_order: BTreeSet<Id> = self.nodes.keys().copied().collect();
+        while !to_order.is_empty() {
+            let mut next_layer = to_order.clone();
+            for ((a, _), (b, _)) in &edges {
+                if let (Some(a), Some(b)) = (a, b) {
+                    if to_order.contains(b) {
+                        next_layer.remove(a);
+                    }
+                }
+            }
+            to_order.retain(|node| !next_layer.contains(node));
+
+            let mut next_layer: Vec<Id> = next_layer.into_iter().collect();
+            next_layer.sort(); // determinism
+            layers.push(next_layer);
+        }
+
+        let sizes: Vec<Size> = layers
+            .iter()
+            .map(|layer| Size {
+                width: layer.iter().map(|node| children[node].0.width).sum::<f32>(),
+                height: layer
+                    .iter()
+                    .map(|node| children[node].0.height)
+                    .max_by(f32::total_cmp)
+                    .unwrap(),
+            })
+            .collect();
+
+        let size = Size {
+            width: sizes.iter().map(|s| s.width).sum::<f32>()
+                + NODE_SPACING * (children.len() + 1) as f32,
+            height: sizes.iter().map(|s| s.height).sum::<f32>()
+                + NODE_SPACING * (layers.len() + 1) as f32,
+        };
+
+        let mut w = NODE_SPACING;
+        let mut h = NODE_SPACING;
+        let positions: BTreeMap<Id, (f32, f32)> = layers
+            .iter()
+            .zip(sizes)
+            .rev()
+            .flat_map(|(nodes, Size { height, .. })| {
+                let out: Vec<_> = nodes
+                    .iter()
+                    .map(|node| {
+                        let out = (*node, (w, h));
+                        w += children[node].0.width + NODE_SPACING;
+                        out
+                    })
+                    .collect();
+                h += height + NODE_SPACING;
+                out
+            })
+            .collect();
+        assert_eq!(w, size.width);
+        assert_eq!(h, size.height);
+
+        let edges = Xml::group(edges.iter().map(|((a, i), (b, j))| {
+            let (a_x, a_y) = match a {
+                None => (blend(size.width, self.srcs, *i), 0.0),
+                Some(a) => (
+                    positions[a].0 + self.nodes[a].outputs(children[&a].0.width)[*i],
+                    positions[a].1 + children[&a].0.height,
+                ),
+            };
+            let (b_x, b_y) = match b {
+                None => (blend(size.width, self.dsts, *j), size.height),
+                Some(b) => (
+                    positions[b].0 + self.nodes[b].inputs(children[b].0.width)[*j],
+                    positions[b].1,
+                ),
+            };
+
+            let break_y = match a {
+                _ if b.is_none() => {
+                    b_y - NODE_SPACING
+                        + CORNER_RADIUS
+                        + blend(NODE_SPACING - CORNER_RADIUS * 2.0, self.dsts, *j)
+                }
+                Some(a) => {
+                    let layer = layers.iter().find(|layer| layer.contains(a)).unwrap();
+                    let total = layer
+                        .iter()
+                        .map(|node| self.nodes[node].outputs(0.0).len())
+                        .sum();
+                    let mut index = 0;
+                    for node in layer.iter().rev() {
+                        if node == a {
+                            index += *i;
+                            break;
+                        }
+                        index += self.nodes[node].outputs(0.0).len();
+                    }
+                    a_y + CORNER_RADIUS + blend(NODE_SPACING - CORNER_RADIUS * 2.0, total, index)
+                }
+                None => {
+                    a_y + CORNER_RADIUS + blend(NODE_SPACING - CORNER_RADIUS * 2.0, self.srcs, *i)
+                }
+            };
+
+            let positive_offset = ((b_x - a_x) * 0.5).abs().min(CORNER_RADIUS);
+            let direction_offset = match a_x < b_x {
+                true => positive_offset,
+                false => -positive_offset,
+            };
+            let arc_1_a_y = break_y - CORNER_RADIUS;
+            let arc_1_b_x = a_x + direction_offset;
+            let arc_2_a_x = b_x - direction_offset;
+            let arc_2_b_y = break_y + CORNER_RADIUS;
+
+            let path_string = format!(
+                "M {a_x} {a_y}\
+                 V {arc_1_a_y}\
+                 Q {a_x} {break_y} {arc_1_b_x} {break_y}\
+                 H {arc_2_a_x}\
+                 Q {b_x} {break_y} {b_x} {arc_2_b_y}\
+                 V {b_y}"
+            );
+            Xml::new(
+                "path",
+                [
+                    ("fill", "transparent"),
+                    ("stroke", "black"),
+                    ("stroke-linecap", "round"),
+                    ("stroke-width", &format!("{}", STROKE_WIDTH)),
+                    ("d", &path_string),
+                ],
+                "",
+            )
+        }));
+
+        let (s, d) = (self.srcs, self.dsts);
+        let c = |p| if p == 0 && in_loop { "black" } else { "white" };
+        let srcs = Xml::group((0..s).map(|p| port(blend(size.width, s, p), 0.0, "white")));
+        let dsts = Xml::group((0..d).map(|p| port(blend(size.width, d, p), size.height, c(p))));
+
+        let nodes = Xml::group(positions.iter().map(|(id, (x, y))| {
+            let (_, mut xml) = children.remove(id).unwrap();
+            xml.attributes
+                .insert("transform".to_owned(), format!("translate({x}, {y})"));
+            xml
+        }));
+
+        let background = Xml::new(
+            "rect",
+            [
+                ("fill", "white"),
+                ("stroke", "black"),
+                ("stroke-width", &format!("{}", STROKE_WIDTH)),
+                ("width", &format!("{}", size.width)),
+                ("height", &format!("{}", size.height)),
+                ("rx", &format!("{}", CORNER_RADIUS)),
+            ],
+            "",
+        );
+
+        (size, Xml::group([background, edges, nodes, srcs, dsts]))
+    }
+}
+
+impl Region {
+    fn to_svg(&self) -> String {
+        let (size, xml) = self.to_xml(false);
+        let svg = Xml::new(
+            "svg",
+            [
+                ("version", "1.1"),
+                ("width", &format!("{}", size.width)),
+                ("height", &format!("{}", size.height)),
+                ("xmlns", "http://www.w3.org/2000/svg"),
+            ],
+            &xml.to_string(),
+        );
+
+        svg.to_string()
+    }
+}
+
+fn mk_node_and_input_edges(index: Id, nodes: &[RvsdgBody]) -> (Node, Vec<Edge>) {
+    let (node, operands): (Node, Vec<Operand>) = match &nodes[index] {
+        RvsdgBody::PureOp(Expr::Op(f, xs)) => {
+            (Node::Unit(format!("{f}"), xs.len(), 1), xs.to_vec())
+        }
+        RvsdgBody::PureOp(Expr::Call(f, xs)) => (
+            Node::Unit(
+                match f {
+                    Identifier::Name(s) => (**s).to_owned(),
+                    Identifier::Num(x) => format!("{x}"),
+                },
+                xs.len(),
+                1,
+            ),
+            xs.to_vec(),
+        ),
+        RvsdgBody::PureOp(Expr::Const(ConstOps::Const, _, v)) => {
+            (Node::Unit(format!("{v}"), 0, 1), vec![])
+        }
+        RvsdgBody::Gamma {
+            pred,
+            inputs,
+            outputs,
+        } => (
+            Node::Match(
+                outputs
+                    .iter()
+                    .enumerate()
+                    .map(|(pred, os)| (format!("{pred}"), mk_region(inputs.len(), os, nodes)))
+                    .collect(),
+            ),
+            once(pred).chain(inputs).copied().collect::<Vec<_>>(),
+        ),
+        RvsdgBody::Theta {
+            pred,
+            inputs,
+            outputs,
+        } => (
+            Node::Loop(mk_region(
+                inputs.len(),
+                &once(pred).chain(outputs).copied().collect::<Vec<_>>(),
+                nodes,
+            )),
+            inputs.to_vec(),
+        ),
+    };
+    let input_edges = operands
+        .iter()
+        .enumerate()
+        .map(|(j, x)| {
+            (
+                match x {
+                    Operand::Arg(i) => (None, *i),
+                    Operand::Id(id) => (Some(*id), 0),
+                    Operand::Project(i, id) => (Some(*id), *i),
+                },
+                (Some(index), j),
+            )
+        })
+        .collect();
+    (node, input_edges)
+}
+
+// returns only nodes in the same REGION as `output`
+fn reachable_nodes(reachable: &mut BTreeSet<Id>, all: &[RvsdgBody], output: Operand) {
+    let id = match output {
+        Operand::Arg(..) => return,
+        Operand::Id(id) => id,
+        Operand::Project(_, id) => id,
+    };
+    if reachable.insert(id) {
+        let inputs = match &all[id] {
+            RvsdgBody::PureOp(Expr::Op(_, xs)) | RvsdgBody::PureOp(Expr::Call(_, xs)) => xs.clone(),
+            RvsdgBody::PureOp(Expr::Const(..)) => vec![],
+            RvsdgBody::Gamma { pred, inputs, .. } => once(pred).chain(inputs).copied().collect(),
+            RvsdgBody::Theta { inputs, .. } => inputs.clone(),
+        };
+        for input in inputs {
+            reachable_nodes(reachable, all, input);
+        }
+    }
+}
+
+fn mk_region(srcs: usize, dsts: &[Operand], nodes: &[RvsdgBody]) -> Region {
+    let mut reachable = BTreeSet::new();
+    dsts.iter().for_each(|operand| {
+        reachable_nodes(&mut reachable, nodes, *operand);
+    });
+
+    let (nodes, edges): (BTreeMap<_, _>, Vec<_>) = reachable
+        .iter()
+        .map(|i| {
+            let (node, edges) = mk_node_and_input_edges(*i, nodes);
+            ((*i, node), edges)
+        })
+        .unzip();
+    let mut edges = edges.concat();
+    // add edges to dsts
+    edges.extend(dsts.iter().enumerate().map(|(j, x)| {
+        (
+            match x {
+                Operand::Arg(i) => (None, *i),
+                Operand::Id(id) => (Some(*id), 0),
+                Operand::Project(i, id) => (Some(*id), *i),
+            },
+            (None, j),
+        )
+    }));
+
+    Region {
+        srcs,
+        dsts: dsts.len(),
+        nodes,
+        edges,
+    }
+}
+
+impl RvsdgFunction {
+    pub(crate) fn to_svg(&self) -> String {
+        let dsts: Vec<_> = self.result.iter().copied().collect();
+        mk_region(self.n_args, &dsts, &self.nodes).to_svg()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bril_rs::{Literal, Type, ValueOps};
+
+    #[test]
+    fn rvsdg2svg_basic() {
+        let svg_old = Region {
+            srcs: 2,
+            dsts: 1,
+            nodes: BTreeMap::from([
+                (
+                    0,
+                    Node::Match(vec![
+                        (
+                            "0".to_owned(),
+                            Region {
+                                srcs: 2,
+                                dsts: 1,
+                                nodes: BTreeMap::from([(0, Node::Unit("0".to_owned(), 0, 1))]),
+                                edges: vec![((Some(0), 0), (None, 0))],
+                            },
+                        ),
+                        (
+                            "1".to_owned(),
+                            Region {
+                                srcs: 2,
+                                dsts: 1,
+                                nodes: BTreeMap::from([(0, Node::Unit("add".to_owned(), 2, 1))]),
+                                edges: vec![
+                                    ((None, 0), (Some(0), 0)),
+                                    ((None, 1), (Some(0), 1)),
+                                    ((Some(0), 0), (None, 0)),
+                                ],
+                            },
+                        ),
+                    ]),
+                ),
+                (
+                    1,
+                    Node::Loop(Region {
+                        srcs: 3,
+                        dsts: 4,
+                        nodes: BTreeMap::from([
+                            (0, Node::Unit("add".to_owned(), 2, 1)),
+                            (1, Node::Unit("1".to_owned(), 0, 1)),
+                            (2, Node::Unit("5".to_owned(), 0, 1)),
+                            (3, Node::Unit("mul".to_owned(), 2, 1)),
+                            (4, Node::Unit("add".to_owned(), 2, 1)),
+                            (5, Node::Unit("eq".to_owned(), 2, 1)),
+                        ]),
+                        edges: vec![
+                            ((None, 0), (Some(0), 0)),
+                            ((Some(1), 0), (Some(0), 1)),
+                            ((None, 0), (Some(3), 0)),
+                            ((Some(2), 0), (Some(3), 1)),
+                            ((Some(2), 0), (Some(4), 0)),
+                            ((None, 2), (Some(4), 1)),
+                            ((Some(5), 0), (None, 0)),
+                            ((Some(0), 0), (None, 1)),
+                            ((Some(3), 0), (None, 2)),
+                            ((Some(4), 0), (None, 3)),
+                            ((Some(0), 0), (Some(5), 0)),
+                            ((Some(2), 0), (Some(5), 1)),
+                        ],
+                    }),
+                ),
+                (2, Node::Unit("add".to_owned(), 2, 1)),
+            ]),
+            edges: vec![
+                ((None, 0), (Some(0), 0)),
+                ((None, 0), (Some(0), 1)),
+                ((None, 1), (Some(0), 2)),
+                ((None, 0), (Some(1), 0)),
+                ((None, 1), (Some(1), 1)),
+                ((None, 0), (Some(1), 2)),
+                ((Some(0), 0), (Some(2), 0)),
+                ((Some(1), 1), (Some(2), 1)),
+                ((Some(2), 0), (None, 0)),
+            ],
+        }
+        .to_svg();
+
+        let svg_new = RvsdgFunction {
+            n_args: 2,
+            nodes: vec![
+                RvsdgBody::PureOp(Expr::Const(ConstOps::Const, Type::Int, Literal::Int(0))),
+                RvsdgBody::PureOp(Expr::Op(
+                    ValueOps::Add,
+                    vec![Operand::Arg(0), Operand::Arg(1)],
+                )),
+                RvsdgBody::Gamma {
+                    pred: Operand::Arg(0),
+                    inputs: vec![Operand::Arg(0), Operand::Arg(1)],
+                    outputs: vec![vec![Operand::Id(0)], vec![Operand::Id(1)]],
+                },
+                RvsdgBody::PureOp(Expr::Op(
+                    ValueOps::Add,
+                    vec![Operand::Arg(0), Operand::Id(4)],
+                )),
+                RvsdgBody::PureOp(Expr::Const(ConstOps::Const, Type::Int, Literal::Int(1))),
+                RvsdgBody::PureOp(Expr::Const(ConstOps::Const, Type::Int, Literal::Int(5))),
+                RvsdgBody::PureOp(Expr::Op(
+                    ValueOps::Mul,
+                    vec![Operand::Arg(0), Operand::Id(5)],
+                )),
+                RvsdgBody::PureOp(Expr::Op(
+                    ValueOps::Add,
+                    vec![Operand::Id(5), Operand::Arg(2)],
+                )),
+                RvsdgBody::PureOp(Expr::Op(ValueOps::Eq, vec![Operand::Id(3), Operand::Id(5)])),
+                RvsdgBody::Theta {
+                    pred: Operand::Id(8),
+                    inputs: vec![Operand::Arg(0), Operand::Arg(1), Operand::Arg(0)],
+                    outputs: vec![Operand::Id(3), Operand::Id(6), Operand::Id(7)],
+                },
+                RvsdgBody::PureOp(Expr::Op(
+                    ValueOps::Add,
+                    vec![Operand::Id(2), Operand::Project(1, 9)],
+                )),
+            ],
+            result: Some(Operand::Id(10)),
+        }
+        .to_svg();
+
+        assert_eq!(svg_old, svg_new);
+    }
+}

--- a/src/rvsdg/tests.rs
+++ b/src/rvsdg/tests.rs
@@ -1,0 +1,347 @@
+use bril_rs::{ConstOps, Literal, Type, ValueOps};
+
+use crate::{
+    cfg::to_cfg,
+    rvsdg::{from_cfg::to_rvsdg, Expr, Id, Operand, RvsdgBody},
+    util::{parse_from_string, DebugVisualizations},
+};
+
+use super::RvsdgFunction;
+
+/// Utility struct for building an RVSDG.
+#[derive(Default)]
+struct RvsdgTest {
+    nodes: Vec<RvsdgBody>,
+}
+
+impl RvsdgTest {
+    fn into_function(self, n_args: usize, output: Operand) -> RvsdgFunction {
+        RvsdgFunction {
+            n_args,
+            nodes: self.nodes,
+            result: Some(output),
+        }
+    }
+
+    fn lit_int(&mut self, i: i64) -> Operand {
+        self.make_node(RvsdgBody::PureOp(Expr::Const(
+            ConstOps::Const,
+            Type::Int,
+            Literal::Int(i),
+        )))
+    }
+
+    fn lit_bool(&mut self, b: bool) -> Operand {
+        self.make_node(RvsdgBody::PureOp(Expr::Const(
+            ConstOps::Const,
+            Type::Bool,
+            Literal::Bool(b),
+        )))
+    }
+
+    fn lt(&mut self, l: Operand, r: Operand) -> Operand {
+        self.make_node(RvsdgBody::PureOp(Expr::Op(ValueOps::Lt, vec![l, r])))
+    }
+
+    fn add(&mut self, l: Operand, r: Operand) -> Operand {
+        self.make_node(RvsdgBody::PureOp(Expr::Op(ValueOps::Add, vec![l, r])))
+    }
+
+    fn mul(&mut self, l: Operand, r: Operand) -> Operand {
+        self.make_node(RvsdgBody::PureOp(Expr::Op(ValueOps::Mul, vec![l, r])))
+    }
+
+    fn gamma(&mut self, pred: Operand, inputs: &[Operand], outputs: &[&[Operand]]) -> Id {
+        let res = self.nodes.len();
+        self.nodes.push(RvsdgBody::Gamma {
+            pred,
+            inputs: inputs.to_vec(),
+            outputs: outputs.iter().map(|outs| outs.to_vec()).collect(),
+        });
+        res
+    }
+
+    fn theta(&mut self, pred: Operand, inputs: &[Operand], outputs: &[Operand]) -> Id {
+        let res = self.nodes.len();
+        self.nodes.push(RvsdgBody::Theta {
+            pred,
+            inputs: inputs.to_vec(),
+            outputs: outputs.to_vec(),
+        });
+        res
+    }
+
+    fn make_node(&mut self, body: RvsdgBody) -> Operand {
+        let res = Operand::Project(0, self.nodes.len());
+        self.nodes.push(body);
+        res
+    }
+}
+
+#[test]
+fn rvsdg_expr() {
+    const PROGRAM: &str = r#"
+    @sub() : int {
+        v0: int = const 1;
+        v1: int = const 2;
+        v2: int = add v0 v1;
+        ret v2;
+    }
+    "#;
+    let prog = parse_from_string(PROGRAM);
+    let mut cfg = to_cfg(&prog.functions[0]);
+    let rvsdg = to_rvsdg(&mut cfg).unwrap();
+
+    let mut expected = RvsdgTest::default();
+    let one = expected.lit_int(1);
+    let two = expected.lit_int(2);
+    let res = expected.add(one, two);
+    assert!(deep_equal(&expected.into_function(0, res), &rvsdg));
+}
+
+#[test]
+fn rvsdg_unstructured() {
+    const PROGRAM: &str = r#"@main(): int {
+        x: int = const 4;
+        a_cond: bool = lt x x;
+        br a_cond .B .C;
+      .B:
+        a: int = const 1;
+        b_cond: bool = lt x a;
+        x: int = add x a;
+        br b_cond .C .D;
+      .C:
+        jmp .B;
+      .D:
+        ret x;
+      }"#;
+    DebugVisualizations::new(PROGRAM)
+        .write_output("/tmp/unstructured_")
+        .unwrap();
+    let prog = parse_from_string(PROGRAM);
+    let mut cfg = to_cfg(&prog.functions[0]);
+    let rvsdg = to_rvsdg(&mut cfg).unwrap();
+    // This example is a bit less natural, and while I believe this is a
+    // faithful RVSDG, it'd be nicer to get further assurance that this is
+    // correct (e.g. by roundtripping this to bril and ensuring the same values
+    // came out).
+    let mut expected = RvsdgTest::default();
+    let four = expected.lit_int(4);
+    let one = expected.lit_int(1);
+    let zero = expected.lit_int(0);
+
+    let pred = expected.lt(four, four);
+    let gamma1 = expected.gamma(pred, &[], &[&[four, one], &[four, zero]]);
+
+    // loop body:
+
+    let pred2 = expected.lt(Operand::Arg(0), one);
+    let in0 = expected.add(Operand::Arg(0), one);
+    let gamma_inner0 = expected.gamma(
+        pred2,
+        &[in0, Operand::Arg(1)],
+        &[
+            &[Operand::Arg(0), zero, Operand::Arg(1)],
+            &[Operand::Arg(0), one, one],
+        ],
+    );
+
+    let gamma_outer = expected.gamma(
+        zero,
+        &[Operand::Arg(0), Operand::Arg(1)],
+        &[
+            &[
+                Operand::Project(0, gamma_inner0),
+                Operand::Project(1, gamma_inner0),
+                Operand::Project(2, gamma_inner0),
+            ],
+            &[Operand::Arg(0), one, zero],
+        ],
+    );
+
+    let res = expected.theta(
+        Operand::Project(1, gamma_outer),
+        &[Operand::Project(0, gamma1), Operand::Project(1, gamma1)],
+        &[
+            Operand::Project(0, gamma_outer),
+            Operand::Project(2, gamma_outer),
+        ],
+    );
+
+    assert!(deep_equal(
+        &expected.into_function(0, Operand::Project(0, res)),
+        &rvsdg
+    ));
+}
+
+#[test]
+fn rvsdg_basic_odd_branch() {
+    // Bril program summing the numbers from 1 to n, multiplying by 2 if that
+    // value is larger is larger than 5. This gives us a theta node and a gamma
+    // node, with the gamma requiring branch restructuring.
+    const PROGRAM: &str = r#"
+ @main(n: int): int {
+    res: int = const 0;
+    i: int = const 0;
+ .loop:
+    one: int = const 1;
+    res: int = add res i;
+    i: int = add i one;
+    loop_cond: bool = lt i n;
+    br loop_cond .loop .tail;
+ .tail:
+   five: int = const 5;
+   rescale_cond: bool = lt res five;
+   br rescale_cond .rescale .exit;
+ .rescale:
+   two: int = const 2;
+   res: int = mul res two;
+ .exit:
+  ret res;
+}"#;
+
+    let mut expected = RvsdgTest::default();
+    let zero = expected.lit_int(0);
+    let one = expected.lit_int(1);
+    let two = expected.lit_int(2);
+    let five = expected.lit_int(5);
+
+    // loop variables
+    let res = Operand::Arg(0);
+    let i = Operand::Arg(1);
+    let n = Operand::Arg(2);
+
+    let ip1 = expected.add(i, one);
+    let rpi = expected.add(res, i);
+    let pred = expected.lt(ip1, n);
+    let theta = expected.theta(
+        pred,
+        &[zero, zero, Operand::Arg(0)],
+        &[
+            // res = res + i
+            rpi, // i = i + 1
+            ip1, // n = n
+            n,
+        ],
+    );
+    let res = Operand::Project(0, theta);
+    let pred = expected.lt(res, five);
+    let mul2 = expected.mul(Operand::Arg(0), two);
+    let gamma = expected.gamma(pred, &[res], &[&[Operand::Arg(0)], &[mul2]]);
+    let prog = parse_from_string(PROGRAM);
+    let mut cfg = to_cfg(&prog.functions[0]);
+    let got = to_rvsdg(&mut cfg).unwrap();
+    assert!(deep_equal(
+        &expected.into_function(1, Operand::Project(0, gamma)),
+        &got
+    ));
+}
+
+/// We don't want to commit to the order in which nodes are laid out, so we do a
+/// DFS to check if two functions are equal for the purposes of testing.
+fn deep_equal(f1: &RvsdgFunction, f2: &RvsdgFunction) -> bool {
+    if f1.n_args != f2.n_args {
+        return false;
+    }
+
+    fn ops_equal(o1: &Operand, o2: &Operand, f1: &RvsdgFunction, f2: &RvsdgFunction) -> bool {
+        match (o1, o2) {
+            (Operand::Arg(x), Operand::Arg(y)) => x == y,
+            (Operand::Project(p1, l), Operand::Project(p2, r)) => {
+                p1 == p2 && ids_equal(*l, *r, f1, f2)
+            }
+            (Operand::Id(l), Operand::Id(r))
+            | (Operand::Project(0, l), Operand::Id(r))
+            | (Operand::Id(l), Operand::Project(0, r)) => ids_equal(*l, *r, f1, f2),
+            (Operand::Arg(_), Operand::Id(_))
+            | (Operand::Arg(_), Operand::Project(_, _))
+            | (Operand::Id(_), Operand::Arg(_))
+            | (Operand::Project(_, _), Operand::Arg(_))
+            | (Operand::Project(_, _), Operand::Id(_))
+            | (Operand::Id(_), Operand::Project(_, _)) => false,
+        }
+    }
+
+    fn all_equal(
+        ops1: &[Operand],
+        ops2: &[Operand],
+        f1: &RvsdgFunction,
+        f2: &RvsdgFunction,
+    ) -> bool {
+        ops1.len() == ops2.len()
+            && ops1
+                .iter()
+                .zip(ops2.iter())
+                .all(|(l, r)| ops_equal(l, r, f1, f2))
+    }
+
+    fn ids_equal(i1: Id, i2: Id, f1: &RvsdgFunction, f2: &RvsdgFunction) -> bool {
+        match (&f1.nodes[i1], &f2.nodes[i2]) {
+            (RvsdgBody::PureOp(l), RvsdgBody::PureOp(r)) => match (l, r) {
+                (Expr::Op(vo1, as1), Expr::Op(vo2, as2)) => {
+                    vo1 == vo2 && all_equal(as1, as2, f1, f2)
+                }
+                (Expr::Call(func1, as1), Expr::Call(func2, as2)) => {
+                    func1 == func2 && all_equal(as1, as2, f1, f2)
+                }
+                (Expr::Const(c1, ty1, lit1), Expr::Const(c2, ty2, lit2)) => {
+                    c1 == c2 && ty1 == ty2 && lit1 == lit2
+                }
+                (Expr::Call(_, _), Expr::Op(_, _))
+                | (Expr::Call(_, _), Expr::Const(_, _, _))
+                | (Expr::Const(_, _, _), Expr::Call(_, _))
+                | (Expr::Const(_, _, _), Expr::Op(_, _))
+                | (Expr::Op(_, _), Expr::Call(_, _))
+                | (Expr::Op(_, _), Expr::Const(_, _, _)) => false,
+            },
+            (
+                RvsdgBody::Theta {
+                    pred: p1,
+                    inputs: is1,
+                    outputs: os1,
+                },
+                RvsdgBody::Theta {
+                    pred: p2,
+                    inputs: is2,
+                    outputs: os2,
+                },
+            ) => {
+                ops_equal(p1, p2, f1, f2)
+                    && all_equal(is1, is2, f1, f2)
+                    && all_equal(os1, os2, f1, f2)
+            }
+            (
+                RvsdgBody::Gamma {
+                    pred: p1,
+                    inputs: is1,
+                    outputs: os1,
+                },
+                RvsdgBody::Gamma {
+                    pred: p2,
+                    inputs: is2,
+                    outputs: os2,
+                },
+            ) => {
+                if !ops_equal(p1, p2, f1, f2) || !all_equal(is1, is2, f1, f2) {
+                    return false;
+                }
+                os1.len() == os2.len()
+                    && os1
+                        .iter()
+                        .zip(os2.iter())
+                        .all(|(l, r)| all_equal(l, r, f1, f2))
+            }
+            (RvsdgBody::PureOp(_), RvsdgBody::Gamma { .. })
+            | (RvsdgBody::PureOp(_), RvsdgBody::Theta { .. })
+            | (RvsdgBody::Gamma { .. }, RvsdgBody::Theta { .. })
+            | (RvsdgBody::Gamma { .. }, RvsdgBody::PureOp(_))
+            | (RvsdgBody::Theta { .. }, RvsdgBody::PureOp(_))
+            | (RvsdgBody::Theta { .. }, RvsdgBody::Gamma { .. }) => false,
+        }
+    }
+
+    match (&f1.result, &f2.result) {
+        (Some(o1), Some(o2)) => ops_equal(o1, o2, f1, f2),
+        (None, None) | (None, Some(_)) | (Some(_), None) => false,
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,8 @@
-use std::fmt::Display;
+use std::{fmt::Display, io};
+
+use petgraph::dot::Dot;
+
+use crate::{cfg::to_cfg, rvsdg::from_cfg::to_rvsdg};
 
 pub(crate) struct ListDisplay<'a, TS>(pub TS, pub &'a str);
 
@@ -15,6 +19,87 @@ where
             }
             Display::fmt(&item, f)?;
             did_something = true;
+        }
+        Ok(())
+    }
+}
+
+/// Parse a string containing a bril program (in text format) into a Program.
+///
+/// This function is intended for use in tests and in ad-hoc debugging.
+#[allow(unused)]
+pub(crate) fn parse_from_string(input: &str) -> bril_rs::Program {
+    use bril2json::parse_abstract_program_from_read;
+    use bril_rs::load_program_from_read;
+    let abs_program = parse_abstract_program_from_read(input.as_bytes(), true, false, None);
+    let mut buf = Vec::new();
+    serde_json::to_writer_pretty(&mut buf, &abs_program).unwrap();
+    buf.push(b'\n');
+    let json_str = String::from_utf8(buf).unwrap();
+    load_program_from_read(json_str.as_bytes())
+}
+
+/// Visual representations of intermediate representations computed on a bril
+/// program.
+///
+/// This struct is intended for use in debugging eggcc. SVG visualizations can
+/// be opened directly in a web browser. Dot visualizations can be converted to
+/// (e.g.) PNGs with utilities like graphviz, e.g.
+/// `dot -Tpng input_cfg.dot -o input_cfg.png`.
+#[allow(unused)]
+pub(crate) struct DebugVisualizations {
+    /// The raw CFG before any restructuring, in Dot format.
+    pub(crate) input_cfg: String,
+    /// The restructured CFG ready for RVSDG conversion, in Dot format.
+    pub(crate) restructured_cfg: String,
+    /// The RVSDG, rendered in SVG format.
+    pub(crate) rvsdg: String,
+}
+
+impl DebugVisualizations {
+    /// Compute visualizations for the given bril program.
+    ///
+    /// This function is intended for use in debugging.
+    ///
+    /// # Panics
+    /// Any failures in the conversion to CFG or RVSDG will cause a panic.
+    #[allow(unused)]
+    pub(crate) fn new(input: &str) -> DebugVisualizations {
+        let program = parse_from_string(input);
+        let mut cfg = to_cfg(&program.functions[0]);
+        let input_cfg = format!("{:#?}", Dot::new(&cfg.graph));
+        let restructured_cfg = {
+            let mut cfg = cfg.clone();
+            cfg.restructure();
+            format!("{:#?}", Dot::new(&cfg.graph))
+        };
+        let rvsdg = to_rvsdg(&mut cfg).unwrap().to_svg();
+        DebugVisualizations {
+            input_cfg,
+            restructured_cfg,
+            rvsdg,
+        }
+    }
+
+    /// Write the visualizations to output files with the given prefix.
+    ///
+    /// * The `input_cfg` field is written to `prefix` + `input_cfg.dot`.
+    /// * The `restructured_cfg` field is written to `prefix` + `restructured.dot`.
+    /// * The `rvsdg` field is written to `prefix` + `rvsdg.svg`.
+    ///
+    /// Like other utilities related to `DebugVisualizations`, this method is
+    /// only intended for debugging eggcc.
+    #[allow(unused)]
+    pub(crate) fn write_output(&self, prefix: impl AsRef<str>) -> io::Result<()> {
+        use std::fs::File;
+        use std::io::Write;
+        for (name, content) in &[
+            ("input_cfg.dot", &self.input_cfg),
+            ("restructured_cfg.dot", &self.restructured_cfg),
+            ("rvsdg.svg", &self.rvsdg),
+        ] {
+            let mut file = File::create(format!("{}{}", prefix.as_ref(), name))?;
+            file.write_all(content.as_bytes())?;
         }
         Ok(())
     }


### PR DESCRIPTION
This PR provides initial support for conversion from bril to RVSDGs, including a restructuring pass that converts unstructured CFGs into structured ones. Missing are:

* Support for side-effects (like memory, or print)
* An egglog representation, though this PR unblocks Yihong's work on this front.
* Translation back into a CFG.

Translation back into a CFG will allow us to increase test coverage more: there are unit tests here, but writing unit tests manually is error-prone and time-consuming. Adding more translation functions will let us automate tests for larger / trickier examples.