### PR TITLE
PEGs in Rust

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ use thiserror::Error;
 
 pub(crate) mod cfg;
 mod conversions;
+pub(crate) mod peg;
 pub(crate) mod rvsdg;
 mod util;
 use cfg::structured::StructuredProgram;

--- a/src/peg/mod.rs
+++ b/src/peg/mod.rs
@@ -10,6 +10,8 @@
 // todo: remove this once it no longer does anything
 #![allow(dead_code)]
 
+pub(crate) mod simulate;
+
 use crate::rvsdg::{Expr, Id, Operand, RvsdgBody, RvsdgFunction};
 use std::collections::HashMap;
 

--- a/src/peg/mod.rs
+++ b/src/peg/mod.rs
@@ -17,6 +17,7 @@ use std::collections::HashMap;
 mod tests;
 
 /// An expression, expressed using PEGs.
+#[derive(Debug, PartialEq)]
 pub(crate) enum PegBody {
     /// A pure operation.
     PureOp(Expr<Id>),
@@ -34,6 +35,7 @@ pub(crate) enum PegBody {
 }
 
 /// A function, expressed using PEGs.
+#[derive(Debug, PartialEq)]
 pub(crate) struct PegFunction {
     /// The number of arguments to the function.
     pub(crate) n_args: usize,

--- a/src/peg/mod.rs
+++ b/src/peg/mod.rs
@@ -1,0 +1,8 @@
+//! Convert bril programs to PEGs.
+//!
+//! # References
+//!
+//! * ["Equality Saturation: A New Approach to Optimization"](https://arxiv.org/abs/1012.1802)
+//! by Tate, Stepp, Tatlock, and Lerner
+
+use crate::cfg::{ret_id, Annotation, BranchOp, Cfg, CondVal, Identifier};

--- a/src/peg/mod.rs
+++ b/src/peg/mod.rs
@@ -5,4 +5,19 @@
 //! * ["Equality Saturation: A New Approach to Optimization"](https://arxiv.org/abs/1012.1802)
 //! by Tate, Stepp, Tatlock, and Lerner
 
-use crate::cfg::{ret_id, Annotation, BranchOp, Cfg, CondVal, Identifier};
+use crate::rvsdg::{Expr, Operand};
+
+/// Define PEGs in terms of RVSDG units.
+#[allow(dead_code)]
+pub(crate) enum Peg {
+    PureOp(Expr),
+    Phi {
+        pred: Operand,
+        if_true: Operand,
+        if_false: Operand,
+    },
+    Theta {
+        init: Operand,
+        loop_: Operand,
+    },
+}

--- a/src/peg/mod.rs
+++ b/src/peg/mod.rs
@@ -148,6 +148,14 @@ fn get_pegs(
                     inputs,
                     outputs,
                 } => {
+                    // Layout in `pegs`: thetas, evals, pass internals, pass, theta internals
+                    let theta_start = pegs.len();
+                    let evals_start = theta_start + outputs.len();
+                    let pass = evals_start + outputs.len();
+                    for i in 0..outputs.len() {
+                        memoize.insert((i, id), evals_start + i);
+                    }
+
                     let mut scope = scope.to_owned();
                     scope.push(id);
 
@@ -163,14 +171,6 @@ fn get_pegs(
                             )
                         })
                         .collect();
-
-                    // Layout in `pegs`: theta internals, thetas, evals, pass internals, pass
-                    let theta_start = pegs.len();
-                    let evals_start = theta_start + outputs.len();
-                    let pass = evals_start + outputs.len();
-                    for i in 0..outputs.len() {
-                        memoize.insert((i, id), evals_start + i);
-                    }
 
                     pegs.extend(thetas);
                     pegs.extend(

--- a/src/peg/mod.rs
+++ b/src/peg/mod.rs
@@ -1,23 +1,32 @@
-//! Convert bril programs to PEGs.
+//! Convert RVSDGs to PEGs. This is a shortcut to avoid duplicating the work of
+//! analyzing the CFG as loops and ifs, as well as making it easier to do
+//! interoperation between the two dataflow representations.
 //!
 //! # References
 //!
 //! * ["Equality Saturation: A New Approach to Optimization"](https://arxiv.org/abs/1012.1802)
 //! by Tate, Stepp, Tatlock, and Lerner
 
-use crate::rvsdg::{Expr, Operand};
+use crate::rvsdg::{Expr, Id};
 
-/// Define PEGs in terms of RVSDG units.
-#[allow(dead_code)]
+/// An expression, expressed using PEGs.
 pub(crate) enum Peg {
-    PureOp(Expr),
-    Phi {
-        pred: Operand,
-        if_true: Operand,
-        if_false: Operand,
-    },
-    Theta {
-        init: Operand,
-        loop_: Operand,
-    },
+    /// A pure operation.
+    PureOp(Expr<Id>),
+    /// An argument of the enclosing function.
+    Arg(usize),
+    /// An if statement..
+    Phi(Id, Id, Id),
+    /// A stream that represents a loop.
+    Theta(Id, Id),
+}
+
+/// A function, expressed using PEGs.
+pub(crate) struct PegFunction {
+    /// The number of arguments to the function.
+    pub(crate) n_args: usize,
+    /// The backing heap for Peg nodes within this function.
+    pub(crate) nodes: Vec<Peg>,
+    /// The (optional) result pointing into this function.
+    pub(crate) result: Option<Id>,
 }

--- a/src/peg/mod.rs
+++ b/src/peg/mod.rs
@@ -7,12 +7,13 @@
 //! * ["Equality Saturation: A New Approach to Optimization"](https://arxiv.org/abs/1012.1802)
 //! by Tate, Stepp, Tatlock, and Lerner
 
-use crate::rvsdg::{Expr, Id};
+use crate::rvsdg::{Expr, Id, Operand, RvsdgBody, RvsdgFunction};
+use std::collections::HashMap;
 
 /// An expression, expressed using PEGs.
-pub(crate) enum Peg {
+pub(crate) enum PegBody {
     /// A pure operation.
-    PureOp(Expr<Id>),
+    PureOp(Expr),
     /// An argument of the enclosing function.
     Arg(usize),
     /// An if statement..
@@ -26,7 +27,94 @@ pub(crate) struct PegFunction {
     /// The number of arguments to the function.
     pub(crate) n_args: usize,
     /// The backing heap for Peg nodes within this function.
-    pub(crate) nodes: Vec<Peg>,
+    pub(crate) nodes: Vec<PegBody>,
     /// The (optional) result pointing into this function.
     pub(crate) result: Option<Id>,
+}
+
+impl PegFunction {
+    #[allow(dead_code)]
+    pub fn new(rvsdg: &RvsdgFunction) -> PegFunction {
+        let mut nodes = Vec::new();
+        let mut memoize = HashMap::new();
+        let result = rvsdg
+            .result
+            .map(|op| get_pegs(op, &rvsdg.nodes, &[], &mut nodes, &mut memoize));
+        PegFunction {
+            n_args: rvsdg.n_args,
+            nodes,
+            result,
+        }
+    }
+}
+
+fn get_pegs(
+    op: Operand,
+    rvsdgs: &Vec<RvsdgBody>,
+    scope: &[Id],
+    pegs: &mut Vec<PegBody>,
+    memoize: &mut HashMap<Operand, usize>,
+) -> usize {
+    if let Some(out) = memoize.get(&op) {
+        return *out;
+    }
+    match (op, scope.last()) {
+        (Operand::Arg(arg), None) => {
+            let out = pegs.len();
+            pegs.push(PegBody::Arg(arg));
+            memoize.insert(op, out);
+            out
+        }
+        (Operand::Arg(arg), Some(id)) => match &rvsdgs[*id] {
+            RvsdgBody::PureOp(_) => panic!("pure ops shouldn't contain regions"),
+            RvsdgBody::Gamma { inputs, .. } => {
+                let mut scope = scope.to_owned();
+                scope.pop();
+                get_pegs(inputs[arg], rvsdgs, &scope, pegs, memoize)
+            }
+            RvsdgBody::Theta { .. } => todo!(),
+        },
+        (Operand::Id(id), _) | (Operand::Project(_, id), _) => {
+            let selected = match op {
+                Operand::Arg(_) => unreachable!(),
+                Operand::Id(_) => 0,
+                Operand::Project(i, _) => i,
+            };
+            match &rvsdgs[id] {
+                RvsdgBody::PureOp(expr) => {
+                    assert_eq!(0, selected);
+                    let out = pegs.len();
+                    pegs.push(PegBody::PureOp(expr.clone()));
+                    memoize.insert(op, out);
+                    out
+                }
+                RvsdgBody::Gamma { pred, outputs, .. } => {
+                    assert_eq!(2, outputs.len());
+                    let mut scope = scope.to_owned();
+                    scope.push(id);
+                    let phis: Vec<PegBody> = outputs[0]
+                        .iter()
+                        .zip(&outputs[1])
+                        .map(|(if_false, if_true)| {
+                            PegBody::Phi(
+                                get_pegs(*pred, rvsdgs, &scope, pegs, memoize),
+                                get_pegs(*if_true, rvsdgs, &scope, pegs, memoize),
+                                get_pegs(*if_false, rvsdgs, &scope, pegs, memoize),
+                            )
+                        })
+                        .collect();
+                    let out = pegs.len() + selected;
+                    for i in 0..phis.len() {
+                        if i == 0 {
+                            memoize.insert(Operand::Id(id), pegs.len());
+                        }
+                        memoize.insert(Operand::Project(i, id), pegs.len() + i);
+                    }
+                    pegs.extend(phis);
+                    out
+                }
+                RvsdgBody::Theta { .. } => todo!(),
+            }
+        }
+    }
 }

--- a/src/peg/mod.rs
+++ b/src/peg/mod.rs
@@ -7,8 +7,14 @@
 //! * ["Equality Saturation: A New Approach to Optimization"](https://arxiv.org/abs/1012.1802)
 //! by Tate, Stepp, Tatlock, and Lerner
 
+// todo: remove this once it no longer does anything
+#![allow(dead_code)]
+
 use crate::rvsdg::{Expr, Id, Operand, RvsdgBody, RvsdgFunction};
 use std::collections::HashMap;
+
+#[cfg(test)]
+mod tests;
 
 /// An expression, expressed using PEGs.
 pub(crate) enum PegBody {

--- a/src/peg/simulate.rs
+++ b/src/peg/simulate.rs
@@ -81,6 +81,7 @@ impl PegBody {
                     i += 1;
                 }
             }
+            PegBody::Edge(i) => nodes[*i].simulate(args, nodes, indices),
         }
     }
 }
@@ -100,6 +101,7 @@ fn bool(literal: Literal) -> bool {
 }
 
 impl PegFunction {
+    /// IMPORTANT: Graph does not track the order of children!
     pub fn graph(&self) -> Graph<String, &str> {
         let mut graph: Graph<String, &str> = Graph::new();
         let mut edges: Vec<(usize, usize)> = Vec::new();
@@ -135,6 +137,10 @@ impl PegFunction {
                 PegBody::Pass(s, l) => {
                     js = vec![*s];
                     format!("pass_{l}")
+                }
+                PegBody::Edge(x) => {
+                    js = vec![*x];
+                    String::from("no-op")
                 }
             };
             edges.extend(js.into_iter().map(|j| (i, j)));

--- a/src/peg/simulate.rs
+++ b/src/peg/simulate.rs
@@ -2,8 +2,7 @@
 
 use crate::peg::{PegBody, PegFunction};
 use crate::rvsdg::Expr;
-use bril_rs::ValueOps;
-use bril_rs::{ConstOps, Literal};
+use bril_rs::{ConstOps, Literal, ValueOps};
 use petgraph::{graph::NodeIndex, Graph};
 use std::collections::HashMap;
 
@@ -96,6 +95,9 @@ fn int(literal: Literal) -> i64 {
 fn bool(literal: Literal) -> bool {
     match literal {
         Literal::Bool(x) => x,
+        // todo!: the Type shouldn't be necessary, but RVSDG gives the wrong type for
+        // Annotation::AssignCond, and I couldn't figure out what entry_map was doing
+        Literal::Int(x) => x != 0,
         _ => panic!("expected bool, found {literal}"),
     }
 }

--- a/src/peg/simulate.rs
+++ b/src/peg/simulate.rs
@@ -1,0 +1,99 @@
+//! Simulate a PEG.
+
+use crate::peg::{PegBody, PegFunction};
+use crate::rvsdg::Expr;
+use bril_rs::ValueOps;
+use bril_rs::{ConstOps, Literal};
+use std::collections::HashMap;
+
+#[derive(Default)]
+struct Indices(HashMap<usize, usize>);
+
+impl Indices {
+    fn get(&self, label: usize) -> usize {
+        *self.0.get(&label).unwrap_or(&0)
+    }
+
+    fn set(&self, label: usize, value: usize) -> Indices {
+        let mut out = Indices(self.0.clone());
+        out.0.insert(label, value);
+        out
+    }
+}
+
+impl PegFunction {
+    pub fn simulate(&self, args: &[Literal]) -> Option<Literal> {
+        assert_eq!(self.n_args, args.len());
+        self.result
+            .map(|body| self.nodes[body].simulate(args, &self.nodes, &Indices::default()))
+    }
+}
+
+impl PegBody {
+    fn simulate(&self, args: &[Literal], nodes: &[PegBody], indices: &Indices) -> Literal {
+        match self {
+            PegBody::PureOp(expr) => match expr {
+                Expr::Op(op, xs) => {
+                    let xs: Vec<_> = xs
+                        .iter()
+                        .map(|x| nodes[*x].simulate(args, nodes, indices))
+                        .collect();
+                    match op {
+                        ValueOps::Add => Literal::Int(int(xs[0].clone()) + int(xs[1].clone())),
+                        ValueOps::Mul => Literal::Int(int(xs[0].clone()) * int(xs[1].clone())),
+                        ValueOps::Lt => Literal::Bool(int(xs[0].clone()) < int(xs[1].clone())),
+                        op => todo!("implement {op}"),
+                    }
+                }
+                Expr::Call(..) => panic!("can't simulate inter-function calls"),
+                Expr::Const(ConstOps::Const, _, literal) => literal.clone(),
+            },
+            PegBody::Arg(arg) => args[*arg].clone(),
+            PegBody::Phi(c, x, y) => {
+                let c = nodes[*c].simulate(args, nodes, indices);
+                let x = nodes[*x].simulate(args, nodes, indices);
+                let y = nodes[*y].simulate(args, nodes, indices);
+                if bool(c) {
+                    x
+                } else {
+                    y
+                }
+            }
+            PegBody::Theta(a, b, l) => {
+                let c = indices.get(*l);
+                if c == 0 {
+                    nodes[*a].simulate(args, nodes, indices)
+                } else {
+                    nodes[*b].simulate(args, nodes, &indices.set(*l, c - 1))
+                }
+            }
+            PegBody::Eval(s, i, l) => {
+                let i = nodes[*i].simulate(args, nodes, indices);
+                nodes[*s].simulate(args, nodes, &indices.set(*l, int(i).try_into().unwrap()))
+            }
+            PegBody::Pass(s, l) => {
+                let mut i = 0;
+                loop {
+                    if !bool(nodes[*s].simulate(args, nodes, &indices.set(*l, i))) {
+                        return Literal::Int(i.try_into().unwrap());
+                    }
+                    i += 1;
+                }
+            }
+        }
+    }
+}
+
+fn int(literal: Literal) -> i64 {
+    match literal {
+        Literal::Int(x) => x,
+        _ => panic!("expected int, found {literal}"),
+    }
+}
+
+fn bool(literal: Literal) -> bool {
+    match literal {
+        Literal::Bool(x) => x,
+        _ => panic!("expected bool, found {literal}"),
+    }
+}

--- a/src/peg/tests.rs
+++ b/src/peg/tests.rs
@@ -3,6 +3,9 @@ use crate::peg::{PegBody, PegFunction};
 use crate::rvsdg::{from_cfg::to_rvsdg, Expr, Id};
 use crate::util::parse_from_string;
 use bril_rs::{ConstOps, Literal, Type, ValueOps};
+use petgraph::dot::{Config, Dot};
+use std::fs::File;
+use std::io::Write;
 
 /// Utility struct for building an Peg.
 #[derive(Default)]
@@ -72,6 +75,12 @@ impl PegTest {
         self.nodes.push(body);
         res
     }
+}
+
+fn output_dot_graph(name: &str, peg: &PegFunction) {
+    let contents = format!("{}", Dot::with_config(&peg.graph(), &[Config::EdgeNoLabel]));
+    let mut file = File::create(name).unwrap();
+    file.write_all(contents.as_bytes()).unwrap();
 }
 
 #[test]

--- a/src/peg/tests.rs
+++ b/src/peg/tests.rs
@@ -145,15 +145,15 @@ fn peg_basic_odd_branch() {
 
     let prog = parse_from_string(PROGRAM);
     let mut cfg = to_cfg(&prog.functions[0]);
-    let got = PegFunction::new(&to_rvsdg(&mut cfg).unwrap());
+    let have = PegFunction::new(&to_rvsdg(&mut cfg).unwrap());
 
-    for i in 0..10 {
-        assert_eq!(
-            want.simulate(&[Literal::Int(i)]),
-            got.simulate(&[Literal::Int(i)]),
-            "iteration {i}"
-        );
-    }
+    let want: Vec<_> = (0..10)
+        .map(|i| want.simulate(&[Literal::Int(i)]).unwrap())
+        .collect();
+    let have: Vec<_> = (0..10)
+        .map(|i| have.simulate(&[Literal::Int(i)]).unwrap())
+        .collect();
+    assert_eq!(want, have);
 }
 
 // todo

--- a/src/peg/tests.rs
+++ b/src/peg/tests.rs
@@ -48,15 +48,23 @@ impl PegTest {
     }
 
     fn phi(&mut self, if_: Id, then: Id, else_: Id) -> Id {
-        let res = self.nodes.len();
-        self.nodes.push(PegBody::Phi(if_, then, else_));
-        res
+        self.make_node(PegBody::Phi(if_, then, else_))
     }
 
     fn theta(&mut self, init: Id, loop_: Id, label: usize) -> Id {
-        let res = self.nodes.len();
-        self.nodes.push(PegBody::Theta(init, loop_, label));
-        res
+        self.make_node(PegBody::Theta(init, loop_, label))
+    }
+
+    fn arg(&mut self, arg: usize) -> Id {
+        self.make_node(PegBody::Arg(arg))
+    }
+
+    fn eval(&mut self, l: Id, r: Id, label: usize) -> Id {
+        self.make_node(PegBody::Eval(l, r, label))
+    }
+
+    fn pass(&mut self, c: Id, label: usize) -> Id {
+        self.make_node(PegBody::Pass(c, label))
     }
 
     fn make_node(&mut self, body: PegBody) -> Id {
@@ -84,7 +92,7 @@ fn peg_expr() {
     let one = expected.lit_int(1);
     let two = expected.lit_int(2);
     let res = expected.add(one, two);
-    assert!(deep_equal(&expected.into_function(0, res), &peg));
+    assert_eq!(&expected.into_function(0, res), &peg);
 }
 
 // todo
@@ -163,140 +171,55 @@ fn peg_expr() {
 //     ));
 // }
 
-// todo
-// #[test]
-// fn peg_basic_odd_branch() {
-//     // Bril program summing the numbers from 1 to n, multiplying by 2 if that
-//     // value is larger is larger than 5. This gives us a theta node and a phi
-//     // node, with the phi requiring branch restructuring.
-//     const PROGRAM: &str = r#"
-//  @main(n: int): int {
-//     res: int = const 0;
-//     i: int = const 0;
-//  .loop:
-//     one: int = const 1;
-//     res: int = add res i;
-//     i: int = add i one;
-//     loop_cond: bool = lt i n;
-//     br loop_cond .loop .tail;
-//  .tail:
-//    five: int = const 5;
-//    rescale_cond: bool = lt res five;
-//    br rescale_cond .rescale .exit;
-//  .rescale:
-//    two: int = const 2;
-//    res: int = mul res two;
-//  .exit:
-//   ret res;
-// }"#;
+#[test]
+fn peg_basic_odd_branch() {
+    // Bril program summing the numbers from 1 to n, multiplying by 2 if that
+    // value is larger is larger than 5. This gives us a theta node and a phi
+    // node, with the phi requiring branch restructuring.
+    const PROGRAM: &str = r#"
+ @main(n: int): int {
+    res: int = const 0;
+    i: int = const 0;
+ .loop:
+    one: int = const 1;
+    res: int = add res i;
+    i: int = add i one;
+    loop_cond: bool = lt i n;
+    br loop_cond .loop .tail;
+ .tail:
+   five: int = const 5;
+   rescale_cond: bool = lt res five;
+   br rescale_cond .rescale .exit;
+ .rescale:
+   two: int = const 2;
+   res: int = mul res two;
+ .exit:
+  ret res;
+}"#;
 
-//     let mut expected = PegTest::default();
-//     let zero = expected.lit_int(0);
-//     let one = expected.lit_int(1);
-//     let two = expected.lit_int(2);
-//     let five = expected.lit_int(5);
+    let mut expected = PegTest::default();
+    let zero = expected.lit_int(0);
+    let one = expected.lit_int(1);
+    let two = expected.lit_int(2);
+    let five = expected.lit_int(5);
+    let n = expected.arg(0);
 
-//     // loop variables
-//     let res = Operand::Arg(0);
-//     let i = Operand::Arg(1);
-//     let n = Operand::Arg(2);
+    let res = expected.theta(zero, usize::MAX, 0);
+    let i = expected.theta(zero, usize::MAX, 0);
+    let res_plus = expected.add(i, res);
+    let i_plus = expected.add(one, i);
+    expected.nodes[res] = PegBody::Theta(zero, res_plus, 0);
+    expected.nodes[i] = PegBody::Theta(zero, i_plus, 0);
 
-//     let ip1 = expected.add(i, one);
-//     let rpi = expected.add(res, i);
-//     let pred = expected.lt(ip1, n);
-//     let theta = expected.theta(
-//         pred,
-//         &[zero, zero, Operand::Arg(0)],
-//         &[
-//             // res = res + i
-//             rpi, // i = i + 1
-//             ip1, // n = n
-//             n,
-//         ],
-//     );
-//     let res = Operand::Project(0, theta);
-//     let pred = expected.lt(res, five);
-//     let mul2 = expected.mul(Operand::Arg(0), two);
-//     let phi = expected.phi(pred, &[res], &[&[Operand::Arg(0)], &[mul2]]);
-//     let prog = parse_from_string(PROGRAM);
-//     let mut cfg = to_cfg(&prog.functions[0]);
-//     let got = PegFunction::new(&to_rvsdg(&mut cfg).unwrap());
-//     assert!(deep_equal(
-//         &expected.into_function(1, Operand::Project(0, phi)),
-//         &got
-//     ));
-// }
+    let pred = expected.lt(i, n);
+    let pass = expected.pass(pred, 0);
+    let eval = expected.eval(res, pass, 0);
+    let pred = expected.lt(eval, five);
+    let mul2 = expected.mul(eval, two);
+    let phi = expected.phi(pred, mul2, eval);
 
-/// We don't want to commit to the order in which nodes are laid out, so we do a
-/// DFS to check if two functions are equal for the purposes of testing.
-fn deep_equal(f1: &PegFunction, f2: &PegFunction) -> bool {
-    if f1.n_args != f2.n_args {
-        return false;
-    }
-
-    fn all_equal(ids1: &[Id], ids2: &[Id], f1: &PegFunction, f2: &PegFunction) -> bool {
-        ids1.len() == ids2.len()
-            && ids1
-                .iter()
-                .zip(ids2.iter())
-                .all(|(l, r)| ids_equal(*l, *r, f1, f2))
-    }
-
-    fn labels_equal(_label1: usize, _label2: usize, _f1: &PegFunction, _f2: &PegFunction) -> bool {
-        // todo: check that labels are consistent
-        true
-    }
-
-    fn ids_equal(i1: Id, i2: Id, f1: &PegFunction, f2: &PegFunction) -> bool {
-        match (&f1.nodes[i1], &f2.nodes[i2]) {
-            (PegBody::PureOp(l), PegBody::PureOp(r)) => match (l, r) {
-                (Expr::Op(vo1, as1), Expr::Op(vo2, as2)) => {
-                    vo1 == vo2 && all_equal(as1, as2, f1, f2)
-                }
-                (Expr::Call(func1, as1), Expr::Call(func2, as2)) => {
-                    func1 == func2 && all_equal(as1, as2, f1, f2)
-                }
-                (Expr::Const(c1, ty1, lit1), Expr::Const(c2, ty2, lit2)) => {
-                    c1 == c2 && ty1 == ty2 && lit1 == lit2
-                }
-                (Expr::Call(_, _), Expr::Op(_, _))
-                | (Expr::Call(_, _), Expr::Const(_, _, _))
-                | (Expr::Const(_, _, _), Expr::Call(_, _))
-                | (Expr::Const(_, _, _), Expr::Op(_, _))
-                | (Expr::Op(_, _), Expr::Call(_, _))
-                | (Expr::Op(_, _), Expr::Const(_, _, _)) => false,
-            },
-            (PegBody::PureOp(_), _) => false,
-            (PegBody::Theta(p1, is1, label1), PegBody::Theta(p2, is2, label2)) => {
-                ids_equal(*p1, *p2, f1, f2)
-                    && ids_equal(*is1, *is2, f1, f2)
-                    && labels_equal(*label1, *label2, f1, f2)
-            }
-            (PegBody::Theta(..), _) => false,
-            (PegBody::Phi(p1, is1, os1), PegBody::Phi(p2, is2, os2)) => {
-                if !ids_equal(*p1, *p2, f1, f2) || !ids_equal(*is1, *is2, f1, f2) {
-                    return false;
-                }
-                ids_equal(*os1, *os2, f1, f2)
-            }
-            (PegBody::Phi(..), _) => false,
-            (PegBody::Eval(i1, l1, label1), PegBody::Eval(i2, l2, label2)) => {
-                ids_equal(*i1, *i2, f1, f2)
-                    && ids_equal(*l1, *l2, f1, f2)
-                    && labels_equal(*label1, *label2, f1, f2)
-            }
-            (PegBody::Eval(..), _) => false,
-            (PegBody::Pass(i1, label1), PegBody::Pass(i2, label2)) => {
-                ids_equal(*i1, *i2, f1, f2) && labels_equal(*label1, *label2, f1, f2)
-            }
-            (PegBody::Pass(..), _) => false,
-            (PegBody::Arg(a1), PegBody::Arg(a2)) => a1 == a2,
-            (PegBody::Arg(_), _) => false,
-        }
-    }
-
-    match (&f1.result, &f2.result) {
-        (Some(o1), Some(o2)) => ids_equal(*o1, *o2, f1, f2),
-        (None, None) | (None, Some(_)) | (Some(_), None) => false,
-    }
+    let prog = parse_from_string(PROGRAM);
+    let mut cfg = to_cfg(&prog.functions[0]);
+    let got = PegFunction::new(&to_rvsdg(&mut cfg).unwrap());
+    assert_eq!(&expected.into_function(1, phi), &got);
 }

--- a/src/peg/tests.rs
+++ b/src/peg/tests.rs
@@ -182,6 +182,8 @@ fn peg_unstructured() {
         ret x;
       }"#;
 
+    // Since this test doesn't take arguments we could hardcode the output,
+    // but this also serves as an example for other people writing tests.
     let mut expected = PegTest::default();
     let four = expected.lit_int(4);
     let one = expected.lit_int(1);

--- a/src/peg/tests.rs
+++ b/src/peg/tests.rs
@@ -1,0 +1,313 @@
+use crate::cfg::to_cfg;
+use crate::peg::{PegBody, PegFunction};
+use crate::rvsdg::{from_cfg::to_rvsdg, Expr, Id, Operand};
+use crate::util::{parse_from_string, DebugVisualizations};
+use bril_rs::{ConstOps, Literal, Type, ValueOps};
+
+/// Utility struct for building an Peg.
+#[derive(Default)]
+struct PegTest {
+    nodes: Vec<PegBody>,
+}
+
+impl PegTest {
+    fn into_function(self, n_args: usize, output: Id) -> PegFunction {
+        PegFunction {
+            n_args,
+            nodes: self.nodes,
+            result: Some(output),
+        }
+    }
+
+    fn lit_int(&mut self, i: i64) -> Id {
+        self.make_node(PegBody::PureOp(Expr::Const(
+            ConstOps::Const,
+            Type::Int,
+            Literal::Int(i),
+        )))
+    }
+
+    fn lit_bool(&mut self, b: bool) -> Id {
+        self.make_node(PegBody::PureOp(Expr::Const(
+            ConstOps::Const,
+            Type::Bool,
+            Literal::Bool(b),
+        )))
+    }
+
+    fn lt(&mut self, l: Id, r: Id) -> Id {
+        self.make_node(PegBody::PureOp(Expr::Op(
+            ValueOps::Lt,
+            vec![Operand::Id(l), Operand::Id(r)],
+        )))
+    }
+
+    fn add(&mut self, l: Id, r: Id) -> Id {
+        self.make_node(PegBody::PureOp(Expr::Op(
+            ValueOps::Add,
+            vec![Operand::Id(l), Operand::Id(r)],
+        )))
+    }
+
+    fn mul(&mut self, l: Id, r: Id) -> Id {
+        self.make_node(PegBody::PureOp(Expr::Op(
+            ValueOps::Mul,
+            vec![Operand::Id(l), Operand::Id(r)],
+        )))
+    }
+
+    fn phi(&mut self, if_: Id, then: Id, else_: Id) -> Id {
+        let res = self.nodes.len();
+        self.nodes.push(PegBody::Phi(if_, then, else_));
+        res
+    }
+
+    fn theta(&mut self, init: Id, loop_: Id, label: usize) -> Id {
+        let res = self.nodes.len();
+        self.nodes.push(PegBody::Theta(init, loop_, label));
+        res
+    }
+
+    fn make_node(&mut self, body: PegBody) -> usize {
+        let res = self.nodes.len();
+        self.nodes.push(body);
+        res
+    }
+}
+
+#[test]
+fn peg_expr() {
+    const PROGRAM: &str = r#"
+    @sub() : int {
+        v0: int = const 1;
+        v1: int = const 2;
+        v2: int = add v0 v1;
+        ret v2;
+    }
+    "#;
+    let prog = parse_from_string(PROGRAM);
+    let mut cfg = to_cfg(&prog.functions[0]);
+    let peg = PegFunction::new(&to_rvsdg(&mut cfg).unwrap());
+
+    let mut expected = PegTest::default();
+    let one = expected.lit_int(1);
+    let two = expected.lit_int(2);
+    let res = expected.add(one, two);
+    assert!(deep_equal(&expected.into_function(0, res), &peg));
+}
+
+#[test]
+fn peg_unstructured() {
+    const PROGRAM: &str = r#"@main(): int {
+        x: int = const 4;
+        a_cond: bool = lt x x;
+        br a_cond .B .C;
+      .B:
+        a: int = const 1;
+        b_cond: bool = lt x a;
+        x: int = add x a;
+        br b_cond .C .D;
+      .C:
+        jmp .B;
+      .D:
+        ret x;
+      }"#;
+    DebugVisualizations::new(PROGRAM)
+        .write_output("/tmp/unstructured_")
+        .unwrap();
+    let prog = parse_from_string(PROGRAM);
+    let mut cfg = to_cfg(&prog.functions[0]);
+    let peg = to_rvsdg(&mut cfg).unwrap();
+    // This example is a bit less natural, and while I believe this is a
+    // faithful RVSDG, it'd be nicer to get further assurance that this is
+    // correct (e.g. by roundtripping this to bril and ensuring the same values
+    // came out).
+    let mut expected = PegTest::default();
+    let four = expected.lit_int(4);
+    let one = expected.lit_int(1);
+    let zero = expected.lit_int(0);
+
+    let pred = expected.lt(four, four);
+    let phi1 = expected.phi(pred, &[], &[&[four, one], &[four, zero]]);
+
+    // loop body:
+
+    let pred2 = expected.lt(Operand::Arg(0), one);
+    let in0 = expected.add(Operand::Arg(0), one);
+    let phi_inner0 = expected.phi(
+        pred2,
+        &[in0, Operand::Arg(1)],
+        &[
+            &[Operand::Arg(0), zero, Operand::Arg(1)],
+            &[Operand::Arg(0), one, one],
+        ],
+    );
+
+    let phi_outer = expected.phi(
+        zero,
+        &[Operand::Arg(0), Operand::Arg(1)],
+        &[
+            &[
+                Operand::Project(0, phi_inner0),
+                Operand::Project(1, phi_inner0),
+                Operand::Project(2, phi_inner0),
+            ],
+            &[Operand::Arg(0), one, zero],
+        ],
+    );
+
+    let res = expected.theta(
+        Operand::Project(1, phi_outer),
+        &[Operand::Project(0, phi1), Operand::Project(1, phi1)],
+        &[
+            Operand::Project(0, phi_outer),
+            Operand::Project(2, phi_outer),
+        ],
+    );
+
+    assert!(deep_equal(
+        &expected.into_function(0, Operand::Project(0, res)),
+        &peg
+    ));
+}
+
+#[test]
+fn peg_basic_odd_branch() {
+    // Bril program summing the numbers from 1 to n, multiplying by 2 if that
+    // value is larger is larger than 5. This gives us a theta node and a phi
+    // node, with the phi requiring branch restructuring.
+    const PROGRAM: &str = r#"
+ @main(n: int): int {
+    res: int = const 0;
+    i: int = const 0;
+ .loop:
+    one: int = const 1;
+    res: int = add res i;
+    i: int = add i one;
+    loop_cond: bool = lt i n;
+    br loop_cond .loop .tail;
+ .tail:
+   five: int = const 5;
+   rescale_cond: bool = lt res five;
+   br rescale_cond .rescale .exit;
+ .rescale:
+   two: int = const 2;
+   res: int = mul res two;
+ .exit:
+  ret res;
+}"#;
+
+    let mut expected = PegTest::default();
+    let zero = expected.lit_int(0);
+    let one = expected.lit_int(1);
+    let two = expected.lit_int(2);
+    let five = expected.lit_int(5);
+
+    // loop variables
+    let res = Operand::Arg(0);
+    let i = Operand::Arg(1);
+    let n = Operand::Arg(2);
+
+    let ip1 = expected.add(i, one);
+    let rpi = expected.add(res, i);
+    let pred = expected.lt(ip1, n);
+    let theta = expected.theta(
+        pred,
+        &[zero, zero, Operand::Arg(0)],
+        &[
+            // res = res + i
+            rpi, // i = i + 1
+            ip1, // n = n
+            n,
+        ],
+    );
+    let res = Operand::Project(0, theta);
+    let pred = expected.lt(res, five);
+    let mul2 = expected.mul(Operand::Arg(0), two);
+    let phi = expected.phi(pred, &[res], &[&[Operand::Arg(0)], &[mul2]]);
+    let prog = parse_from_string(PROGRAM);
+    let mut cfg = to_cfg(&prog.functions[0]);
+    let got = to_rvsdg(&mut cfg).unwrap();
+    assert!(deep_equal(
+        &expected.into_function(1, Operand::Project(0, phi)),
+        &got
+    ));
+}
+
+/// We don't want to commit to the order in which nodes are laid out, so we do a
+/// DFS to check if two functions are equal for the purposes of testing.
+fn deep_equal(f1: &PegFunction, f2: &PegFunction) -> bool {
+    if f1.n_args != f2.n_args {
+        return false;
+    }
+
+    fn ops_equal(o1: &Operand, o2: &Operand, f1: &PegFunction, f2: &PegFunction) -> bool {
+        match (o1, o2) {
+            (Operand::Arg(x), Operand::Arg(y)) => x == y,
+            (Operand::Project(p1, l), Operand::Project(p2, r)) => {
+                p1 == p2 && ids_equal(*l, *r, f1, f2)
+            }
+            (Operand::Id(l), Operand::Id(r))
+            | (Operand::Project(0, l), Operand::Id(r))
+            | (Operand::Id(l), Operand::Project(0, r)) => ids_equal(*l, *r, f1, f2),
+            (Operand::Arg(_), Operand::Id(_))
+            | (Operand::Arg(_), Operand::Project(_, _))
+            | (Operand::Id(_), Operand::Arg(_))
+            | (Operand::Project(_, _), Operand::Arg(_))
+            | (Operand::Project(_, _), Operand::Id(_))
+            | (Operand::Id(_), Operand::Project(_, _)) => false,
+        }
+    }
+
+    fn all_equal(ids1: &[Operand], ids2: &[Operand], f1: &PegFunction, f2: &PegFunction) -> bool {
+        ids1.len() == ids2.len()
+            && ids1
+                .iter()
+                .zip(ids2.iter())
+                .all(|(l, r)| ops_equal(l, r, f1, f2))
+    }
+
+    fn ids_equal(i1: Id, i2: Id, f1: &PegFunction, f2: &PegFunction) -> bool {
+        match (&f1.nodes[i1], &f2.nodes[i2]) {
+            (PegBody::PureOp(l), PegBody::PureOp(r)) => match (l, r) {
+                (Expr::Op(vo1, as1), Expr::Op(vo2, as2)) => {
+                    vo1 == vo2 && all_equal(as1, as2, f1, f2)
+                }
+                (Expr::Call(func1, as1), Expr::Call(func2, as2)) => {
+                    func1 == func2 && all_equal(as1, as2, f1, f2)
+                }
+                (Expr::Const(c1, ty1, lit1), Expr::Const(c2, ty2, lit2)) => {
+                    c1 == c2 && ty1 == ty2 && lit1 == lit2
+                }
+                (Expr::Call(_, _), Expr::Op(_, _))
+                | (Expr::Call(_, _), Expr::Const(_, _, _))
+                | (Expr::Const(_, _, _), Expr::Call(_, _))
+                | (Expr::Const(_, _, _), Expr::Op(_, _))
+                | (Expr::Op(_, _), Expr::Call(_, _))
+                | (Expr::Op(_, _), Expr::Const(_, _, _)) => false,
+            },
+            (PegBody::Theta(p1, is1, os1), PegBody::Theta(p2, is2, os2)) => {
+                ids_equal(*p1, *p2, f1, f2)
+                    && ids_equal(*is1, *is2, f1, f2)
+                    && ids_equal(*os1, *os2, f1, f2)
+            }
+            (PegBody::Phi(p1, is1, os1), PegBody::Phi(p2, is2, os2)) => {
+                if !ids_equal(*p1, *p2, f1, f2) || !ids_equal(*is1, *is2, f1, f2) {
+                    return false;
+                }
+                ids_equal(*os1, *os2, f1, f2)
+            }
+            (PegBody::PureOp(_), PegBody::Phi { .. })
+            | (PegBody::PureOp(_), PegBody::Theta { .. })
+            | (PegBody::Phi { .. }, PegBody::Theta { .. })
+            | (PegBody::Phi { .. }, PegBody::PureOp(_))
+            | (PegBody::Theta { .. }, PegBody::PureOp(_))
+            | (PegBody::Theta { .. }, PegBody::Phi { .. }) => false,
+        }
+    }
+
+    match (&f1.result, &f2.result) {
+        (Some(o1), Some(o2)) => ids_equal(*o1, *o2, f1, f2),
+        (None, None) | (None, Some(_)) | (Some(_), None) => false,
+    }
+}

--- a/src/peg/tests.rs
+++ b/src/peg/tests.rs
@@ -1,7 +1,7 @@
 use crate::cfg::to_cfg;
 use crate::peg::{PegBody, PegFunction};
-use crate::rvsdg::{from_cfg::to_rvsdg, Expr, Id, Operand};
-use crate::util::{parse_from_string, DebugVisualizations};
+use crate::rvsdg::{from_cfg::to_rvsdg, Expr, Id};
+use crate::util::parse_from_string;
 use bril_rs::{ConstOps, Literal, Type, ValueOps};
 
 /// Utility struct for building an Peg.
@@ -36,24 +36,15 @@ impl PegTest {
     }
 
     fn lt(&mut self, l: Id, r: Id) -> Id {
-        self.make_node(PegBody::PureOp(Expr::Op(
-            ValueOps::Lt,
-            vec![Operand::Id(l), Operand::Id(r)],
-        )))
+        self.make_node(PegBody::PureOp(Expr::Op(ValueOps::Lt, vec![l, r])))
     }
 
     fn add(&mut self, l: Id, r: Id) -> Id {
-        self.make_node(PegBody::PureOp(Expr::Op(
-            ValueOps::Add,
-            vec![Operand::Id(l), Operand::Id(r)],
-        )))
+        self.make_node(PegBody::PureOp(Expr::Op(ValueOps::Add, vec![l, r])))
     }
 
     fn mul(&mut self, l: Id, r: Id) -> Id {
-        self.make_node(PegBody::PureOp(Expr::Op(
-            ValueOps::Mul,
-            vec![Operand::Id(l), Operand::Id(r)],
-        )))
+        self.make_node(PegBody::PureOp(Expr::Op(ValueOps::Mul, vec![l, r])))
     }
 
     fn phi(&mut self, if_: Id, then: Id, else_: Id) -> Id {
@@ -68,7 +59,7 @@ impl PegTest {
         res
     }
 
-    fn make_node(&mut self, body: PegBody) -> usize {
+    fn make_node(&mut self, body: PegBody) -> Id {
         let res = self.nodes.len();
         self.nodes.push(body);
         res
@@ -96,143 +87,145 @@ fn peg_expr() {
     assert!(deep_equal(&expected.into_function(0, res), &peg));
 }
 
-#[test]
-fn peg_unstructured() {
-    const PROGRAM: &str = r#"@main(): int {
-        x: int = const 4;
-        a_cond: bool = lt x x;
-        br a_cond .B .C;
-      .B:
-        a: int = const 1;
-        b_cond: bool = lt x a;
-        x: int = add x a;
-        br b_cond .C .D;
-      .C:
-        jmp .B;
-      .D:
-        ret x;
-      }"#;
-    DebugVisualizations::new(PROGRAM)
-        .write_output("/tmp/unstructured_")
-        .unwrap();
-    let prog = parse_from_string(PROGRAM);
-    let mut cfg = to_cfg(&prog.functions[0]);
-    let peg = to_rvsdg(&mut cfg).unwrap();
-    // This example is a bit less natural, and while I believe this is a
-    // faithful RVSDG, it'd be nicer to get further assurance that this is
-    // correct (e.g. by roundtripping this to bril and ensuring the same values
-    // came out).
-    let mut expected = PegTest::default();
-    let four = expected.lit_int(4);
-    let one = expected.lit_int(1);
-    let zero = expected.lit_int(0);
+// todo
+// #[test]
+// fn peg_unstructured() {
+//     const PROGRAM: &str = r#"@main(): int {
+//         x: int = const 4;
+//         a_cond: bool = lt x x;
+//         br a_cond .B .C;
+//       .B:
+//         a: int = const 1;
+//         b_cond: bool = lt x a;
+//         x: int = add x a;
+//         br b_cond .C .D;
+//       .C:
+//         jmp .B;
+//       .D:
+//         ret x;
+//       }"#;
+//     DebugVisualizations::new(PROGRAM)
+//         .write_output("/tmp/unstructured_")
+//         .unwrap();
+//     let prog = parse_from_string(PROGRAM);
+//     let mut cfg = to_cfg(&prog.functions[0]);
+//     let peg = to_rvsdg(&mut cfg).unwrap();
+//     // This example is a bit less natural, and while I believe this is a
+//     // faithful RVSDG, it'd be nicer to get further assurance that this is
+//     // correct (e.g. by roundtripping this to bril and ensuring the same values
+//     // came out).
+//     let mut expected = PegTest::default();
+//     let four = expected.lit_int(4);
+//     let one = expected.lit_int(1);
+//     let zero = expected.lit_int(0);
 
-    let pred = expected.lt(four, four);
-    let phi1 = expected.phi(pred, &[], &[&[four, one], &[four, zero]]);
+//     let pred = expected.lt(four, four);
+//     let phi1 = expected.phi(pred, &[], &[&[four, one], &[four, zero]]);
 
-    // loop body:
+//     // loop body:
 
-    let pred2 = expected.lt(Operand::Arg(0), one);
-    let in0 = expected.add(Operand::Arg(0), one);
-    let phi_inner0 = expected.phi(
-        pred2,
-        &[in0, Operand::Arg(1)],
-        &[
-            &[Operand::Arg(0), zero, Operand::Arg(1)],
-            &[Operand::Arg(0), one, one],
-        ],
-    );
+//     let pred2 = expected.lt(Operand::Arg(0), one);
+//     let in0 = expected.add(Operand::Arg(0), one);
+//     let phi_inner0 = expected.phi(
+//         pred2,
+//         &[in0, Operand::Arg(1)],
+//         &[
+//             &[Operand::Arg(0), zero, Operand::Arg(1)],
+//             &[Operand::Arg(0), one, one],
+//         ],
+//     );
 
-    let phi_outer = expected.phi(
-        zero,
-        &[Operand::Arg(0), Operand::Arg(1)],
-        &[
-            &[
-                Operand::Project(0, phi_inner0),
-                Operand::Project(1, phi_inner0),
-                Operand::Project(2, phi_inner0),
-            ],
-            &[Operand::Arg(0), one, zero],
-        ],
-    );
+//     let phi_outer = expected.phi(
+//         zero,
+//         &[Operand::Arg(0), Operand::Arg(1)],
+//         &[
+//             &[
+//                 Operand::Project(0, phi_inner0),
+//                 Operand::Project(1, phi_inner0),
+//                 Operand::Project(2, phi_inner0),
+//             ],
+//             &[Operand::Arg(0), one, zero],
+//         ],
+//     );
 
-    let res = expected.theta(
-        Operand::Project(1, phi_outer),
-        &[Operand::Project(0, phi1), Operand::Project(1, phi1)],
-        &[
-            Operand::Project(0, phi_outer),
-            Operand::Project(2, phi_outer),
-        ],
-    );
+//     let res = expected.theta(
+//         Operand::Project(1, phi_outer),
+//         &[Operand::Project(0, phi1), Operand::Project(1, phi1)],
+//         &[
+//             Operand::Project(0, phi_outer),
+//             Operand::Project(2, phi_outer),
+//         ],
+//     );
 
-    assert!(deep_equal(
-        &expected.into_function(0, Operand::Project(0, res)),
-        &peg
-    ));
-}
+//     assert!(deep_equal(
+//         &expected.into_function(0, Operand::Project(0, res)),
+//         &peg
+//     ));
+// }
 
-#[test]
-fn peg_basic_odd_branch() {
-    // Bril program summing the numbers from 1 to n, multiplying by 2 if that
-    // value is larger is larger than 5. This gives us a theta node and a phi
-    // node, with the phi requiring branch restructuring.
-    const PROGRAM: &str = r#"
- @main(n: int): int {
-    res: int = const 0;
-    i: int = const 0;
- .loop:
-    one: int = const 1;
-    res: int = add res i;
-    i: int = add i one;
-    loop_cond: bool = lt i n;
-    br loop_cond .loop .tail;
- .tail:
-   five: int = const 5;
-   rescale_cond: bool = lt res five;
-   br rescale_cond .rescale .exit;
- .rescale:
-   two: int = const 2;
-   res: int = mul res two;
- .exit:
-  ret res;
-}"#;
+// todo
+// #[test]
+// fn peg_basic_odd_branch() {
+//     // Bril program summing the numbers from 1 to n, multiplying by 2 if that
+//     // value is larger is larger than 5. This gives us a theta node and a phi
+//     // node, with the phi requiring branch restructuring.
+//     const PROGRAM: &str = r#"
+//  @main(n: int): int {
+//     res: int = const 0;
+//     i: int = const 0;
+//  .loop:
+//     one: int = const 1;
+//     res: int = add res i;
+//     i: int = add i one;
+//     loop_cond: bool = lt i n;
+//     br loop_cond .loop .tail;
+//  .tail:
+//    five: int = const 5;
+//    rescale_cond: bool = lt res five;
+//    br rescale_cond .rescale .exit;
+//  .rescale:
+//    two: int = const 2;
+//    res: int = mul res two;
+//  .exit:
+//   ret res;
+// }"#;
 
-    let mut expected = PegTest::default();
-    let zero = expected.lit_int(0);
-    let one = expected.lit_int(1);
-    let two = expected.lit_int(2);
-    let five = expected.lit_int(5);
+//     let mut expected = PegTest::default();
+//     let zero = expected.lit_int(0);
+//     let one = expected.lit_int(1);
+//     let two = expected.lit_int(2);
+//     let five = expected.lit_int(5);
 
-    // loop variables
-    let res = Operand::Arg(0);
-    let i = Operand::Arg(1);
-    let n = Operand::Arg(2);
+//     // loop variables
+//     let res = Operand::Arg(0);
+//     let i = Operand::Arg(1);
+//     let n = Operand::Arg(2);
 
-    let ip1 = expected.add(i, one);
-    let rpi = expected.add(res, i);
-    let pred = expected.lt(ip1, n);
-    let theta = expected.theta(
-        pred,
-        &[zero, zero, Operand::Arg(0)],
-        &[
-            // res = res + i
-            rpi, // i = i + 1
-            ip1, // n = n
-            n,
-        ],
-    );
-    let res = Operand::Project(0, theta);
-    let pred = expected.lt(res, five);
-    let mul2 = expected.mul(Operand::Arg(0), two);
-    let phi = expected.phi(pred, &[res], &[&[Operand::Arg(0)], &[mul2]]);
-    let prog = parse_from_string(PROGRAM);
-    let mut cfg = to_cfg(&prog.functions[0]);
-    let got = to_rvsdg(&mut cfg).unwrap();
-    assert!(deep_equal(
-        &expected.into_function(1, Operand::Project(0, phi)),
-        &got
-    ));
-}
+//     let ip1 = expected.add(i, one);
+//     let rpi = expected.add(res, i);
+//     let pred = expected.lt(ip1, n);
+//     let theta = expected.theta(
+//         pred,
+//         &[zero, zero, Operand::Arg(0)],
+//         &[
+//             // res = res + i
+//             rpi, // i = i + 1
+//             ip1, // n = n
+//             n,
+//         ],
+//     );
+//     let res = Operand::Project(0, theta);
+//     let pred = expected.lt(res, five);
+//     let mul2 = expected.mul(Operand::Arg(0), two);
+//     let phi = expected.phi(pred, &[res], &[&[Operand::Arg(0)], &[mul2]]);
+//     let prog = parse_from_string(PROGRAM);
+//     let mut cfg = to_cfg(&prog.functions[0]);
+//     let got = PegFunction::new(&to_rvsdg(&mut cfg).unwrap());
+//     assert!(deep_equal(
+//         &expected.into_function(1, Operand::Project(0, phi)),
+//         &got
+//     ));
+// }
 
 /// We don't want to commit to the order in which nodes are laid out, so we do a
 /// DFS to check if two functions are equal for the purposes of testing.
@@ -241,30 +234,17 @@ fn deep_equal(f1: &PegFunction, f2: &PegFunction) -> bool {
         return false;
     }
 
-    fn ops_equal(o1: &Operand, o2: &Operand, f1: &PegFunction, f2: &PegFunction) -> bool {
-        match (o1, o2) {
-            (Operand::Arg(x), Operand::Arg(y)) => x == y,
-            (Operand::Project(p1, l), Operand::Project(p2, r)) => {
-                p1 == p2 && ids_equal(*l, *r, f1, f2)
-            }
-            (Operand::Id(l), Operand::Id(r))
-            | (Operand::Project(0, l), Operand::Id(r))
-            | (Operand::Id(l), Operand::Project(0, r)) => ids_equal(*l, *r, f1, f2),
-            (Operand::Arg(_), Operand::Id(_))
-            | (Operand::Arg(_), Operand::Project(_, _))
-            | (Operand::Id(_), Operand::Arg(_))
-            | (Operand::Project(_, _), Operand::Arg(_))
-            | (Operand::Project(_, _), Operand::Id(_))
-            | (Operand::Id(_), Operand::Project(_, _)) => false,
-        }
-    }
-
-    fn all_equal(ids1: &[Operand], ids2: &[Operand], f1: &PegFunction, f2: &PegFunction) -> bool {
+    fn all_equal(ids1: &[Id], ids2: &[Id], f1: &PegFunction, f2: &PegFunction) -> bool {
         ids1.len() == ids2.len()
             && ids1
                 .iter()
                 .zip(ids2.iter())
-                .all(|(l, r)| ops_equal(l, r, f1, f2))
+                .all(|(l, r)| ids_equal(*l, *r, f1, f2))
+    }
+
+    fn labels_equal(_label1: usize, _label2: usize, _f1: &PegFunction, _f2: &PegFunction) -> bool {
+        // todo: check that labels are consistent
+        true
     }
 
     fn ids_equal(i1: Id, i2: Id, f1: &PegFunction, f2: &PegFunction) -> bool {
@@ -286,23 +266,32 @@ fn deep_equal(f1: &PegFunction, f2: &PegFunction) -> bool {
                 | (Expr::Op(_, _), Expr::Call(_, _))
                 | (Expr::Op(_, _), Expr::Const(_, _, _)) => false,
             },
-            (PegBody::Theta(p1, is1, os1), PegBody::Theta(p2, is2, os2)) => {
+            (PegBody::PureOp(_), _) => false,
+            (PegBody::Theta(p1, is1, label1), PegBody::Theta(p2, is2, label2)) => {
                 ids_equal(*p1, *p2, f1, f2)
                     && ids_equal(*is1, *is2, f1, f2)
-                    && ids_equal(*os1, *os2, f1, f2)
+                    && labels_equal(*label1, *label2, f1, f2)
             }
+            (PegBody::Theta(..), _) => false,
             (PegBody::Phi(p1, is1, os1), PegBody::Phi(p2, is2, os2)) => {
                 if !ids_equal(*p1, *p2, f1, f2) || !ids_equal(*is1, *is2, f1, f2) {
                     return false;
                 }
                 ids_equal(*os1, *os2, f1, f2)
             }
-            (PegBody::PureOp(_), PegBody::Phi { .. })
-            | (PegBody::PureOp(_), PegBody::Theta { .. })
-            | (PegBody::Phi { .. }, PegBody::Theta { .. })
-            | (PegBody::Phi { .. }, PegBody::PureOp(_))
-            | (PegBody::Theta { .. }, PegBody::PureOp(_))
-            | (PegBody::Theta { .. }, PegBody::Phi { .. }) => false,
+            (PegBody::Phi(..), _) => false,
+            (PegBody::Eval(i1, l1, label1), PegBody::Eval(i2, l2, label2)) => {
+                ids_equal(*i1, *i2, f1, f2)
+                    && ids_equal(*l1, *l2, f1, f2)
+                    && labels_equal(*label1, *label2, f1, f2)
+            }
+            (PegBody::Eval(..), _) => false,
+            (PegBody::Pass(i1, label1), PegBody::Pass(i2, label2)) => {
+                ids_equal(*i1, *i2, f1, f2) && labels_equal(*label1, *label2, f1, f2)
+            }
+            (PegBody::Pass(..), _) => false,
+            (PegBody::Arg(a1), PegBody::Arg(a2)) => a1 == a2,
+            (PegBody::Arg(_), _) => false,
         }
     }
 

--- a/src/rvsdg/mod.rs
+++ b/src/rvsdg/mod.rs
@@ -81,10 +81,10 @@ pub(crate) enum Annotation {
 
 pub(crate) type Id = usize;
 
-#[derive(Clone, Debug)]
-pub(crate) enum Expr {
-    Op(ValueOps, Vec<Operand>),
-    Call(Identifier, Vec<Operand>),
+#[derive(Debug)]
+pub(crate) enum Expr<Op> {
+    Op(ValueOps, Vec<Op>),
+    Call(Identifier, Vec<Op>),
     Const(ConstOps, Type, Literal),
 }
 
@@ -100,7 +100,7 @@ pub(crate) enum Operand {
 
 #[derive(Debug)]
 pub(crate) enum RvsdgBody {
-    PureOp(Expr),
+    PureOp(Expr<Operand>),
     Gamma {
         pred: Operand,
         inputs: Vec<Operand>,

--- a/src/rvsdg/mod.rs
+++ b/src/rvsdg/mod.rs
@@ -81,10 +81,10 @@ pub(crate) enum Annotation {
 
 pub(crate) type Id = usize;
 
-#[derive(Debug)]
-pub(crate) enum Expr<Op> {
-    Op(ValueOps, Vec<Op>),
-    Call(Identifier, Vec<Op>),
+#[derive(Clone, Debug)]
+pub(crate) enum Expr {
+    Op(ValueOps, Vec<Operand>),
+    Call(Identifier, Vec<Operand>),
     Const(ConstOps, Type, Literal),
 }
 
@@ -100,7 +100,7 @@ pub(crate) enum Operand {
 
 #[derive(Debug)]
 pub(crate) enum RvsdgBody {
-    PureOp(Expr<Operand>),
+    PureOp(Expr),
     Gamma {
         pred: Operand,
         inputs: Vec<Operand>,

--- a/src/rvsdg/mod.rs
+++ b/src/rvsdg/mod.rs
@@ -82,9 +82,9 @@ pub(crate) enum Annotation {
 pub(crate) type Id = usize;
 
 #[derive(Debug)]
-pub(crate) enum Expr {
-    Op(ValueOps, Vec<Operand>),
-    Call(Identifier, Vec<Operand>),
+pub(crate) enum Expr<Op> {
+    Op(ValueOps, Vec<Op>),
+    Call(Identifier, Vec<Op>),
     Const(ConstOps, Type, Literal),
 }
 
@@ -100,7 +100,7 @@ pub(crate) enum Operand {
 
 #[derive(Debug)]
 pub(crate) enum RvsdgBody {
-    PureOp(Expr),
+    PureOp(Expr<Operand>),
     Gamma {
         pred: Operand,
         inputs: Vec<Operand>,

--- a/src/rvsdg/mod.rs
+++ b/src/rvsdg/mod.rs
@@ -81,7 +81,7 @@ pub(crate) enum Annotation {
 
 pub(crate) type Id = usize;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub(crate) enum Expr<Op> {
     Op(ValueOps, Vec<Op>),
     Call(Identifier, Vec<Op>),


### PR DESCRIPTION
This PR:
- Creates a Rust representation of PEGs (heavily inspired by the RVSDG encoding).
- Adds a method to convert Rust RVSDGs to Rust PEGs. (This was done so that there wouldn't be two different CFG -> Dataflow functions. However, it does mean that the PEGs are occasionally inefficient because RVSDG theta nodes are currently do-while/tail-controlled, so the translation requires unrolling the theta nodes an extra step.)
- Adds a method to simulate (interpret) a PEG.
- Adds a method to write a PEG out as a .dot file (although ordering of children isn't preserved so it''s slightly misleading).
- Adds some tests for the PEG conversion that mirror the RVSDG tests.