### PR TITLE
Peg visualization cleanup

### DIFF
--- a/src/peg/mod.rs
+++ b/src/peg/mod.rs
@@ -12,7 +12,7 @@
 
 pub(crate) mod simulate;
 
-use crate::rvsdg::{Expr, Id, Operand, RvsdgBody, RvsdgFunction};
+use crate::rvsdg::{Expr, Id, Operand, RvsdgBody, RvsdgFunction, RvsdgProgram};
 use std::collections::HashMap;
 
 #[cfg(test)]
@@ -235,4 +235,16 @@ impl PegBuilder<'_> {
             }
         }
     }
+}
+
+pub struct PegProgram {
+    pub(crate) functions: Vec<PegFunction>,
+}
+
+pub(crate) fn peg_to_rvsdg(
+    RvsdgProgram { functions }: &RvsdgProgram,
+) -> Result<PegProgram, crate::EggCCError> {
+    Ok(PegProgram {
+        functions: functions.iter().map(PegFunction::new).collect(),
+    })
 }

--- a/src/peg/mod.rs
+++ b/src/peg/mod.rs
@@ -10,6 +10,7 @@
 // todo: remove this once it no longer does anything
 #![allow(dead_code)]
 
+pub(crate) mod peg2dot;
 pub(crate) mod simulate;
 
 use crate::rvsdg::{Expr, Id, Operand, RvsdgBody, RvsdgFunction, RvsdgProgram};
@@ -241,10 +242,8 @@ pub struct PegProgram {
     pub(crate) functions: Vec<PegFunction>,
 }
 
-pub(crate) fn peg_to_rvsdg(
-    RvsdgProgram { functions }: &RvsdgProgram,
-) -> Result<PegProgram, crate::EggCCError> {
-    Ok(PegProgram {
+pub(crate) fn rvsdg_to_peg(RvsdgProgram { functions }: &RvsdgProgram) -> PegProgram {
+    PegProgram {
         functions: functions.iter().map(PegFunction::new).collect(),
-    })
+    }
 }

--- a/src/peg/peg2dot.rs
+++ b/src/peg/peg2dot.rs
@@ -1,0 +1,85 @@
+//! Render a PEG into Dot format;
+
+use crate::peg::{PegBody, PegFunction, PegProgram};
+use crate::rvsdg::Expr;
+use bril_rs::ConstOps;
+use std::fmt::Write;
+
+impl PegProgram {
+    /// Get a .dot file representation of a PegProgram.
+    pub fn graph(&self) -> String {
+        let mut graph = String::new();
+        writeln!(graph, "digraph G {{").unwrap();
+        for function in &self.functions {
+            // Replace the "digraph" line with "subgraph".
+            let mut graph = function.graph();
+            let mut subgraph: Vec<_> = graph.lines().collect();
+            subgraph[0] = "subgraph {{";
+            let subgraph = subgraph.join("\n");
+            writeln!(graph, "{}", subgraph).unwrap();
+        }
+        writeln!(graph, "}}").unwrap();
+        graph
+    }
+}
+
+impl PegFunction {
+    /// Get a .dot file representation of a PegFunction.
+    // Doesn't use petgraph because petgraph doesn't track child orderings.
+    pub fn graph(&self) -> String {
+        let mut nodes: Vec<String> = Vec::new();
+        let mut edges: Vec<(usize, usize)> = Vec::new();
+        for (i, node) in self.nodes.iter().enumerate() {
+            let mut js = Vec::new();
+            let node = match node {
+                PegBody::Arg(arg) => format!("arg {arg}"),
+                PegBody::PureOp(expr) => match expr {
+                    Expr::Op(f, xs) => {
+                        js = xs.to_vec();
+                        format!("{f}")
+                    }
+                    Expr::Call(f, xs) => {
+                        js = xs.to_vec();
+                        format!("{f}")
+                    }
+                    Expr::Const(ConstOps::Const, _, literal) => {
+                        format!("{literal}")
+                    }
+                },
+                PegBody::Phi(c, x, y) => {
+                    js = vec![*c, *x, *y];
+                    String::from("Φ")
+                }
+                PegBody::Theta(a, b, l) => {
+                    js = vec![*a, *b];
+                    format!("Θ_{l}")
+                }
+                PegBody::Eval(s, i, l) => {
+                    js = vec![*s, *i];
+                    format!("eval_{l}")
+                }
+                PegBody::Pass(s, l) => {
+                    js = vec![*s];
+                    format!("pass_{l}")
+                }
+                PegBody::Edge(x) => {
+                    js = vec![*x];
+                    String::from("no-op")
+                }
+            };
+            nodes.push(node);
+            edges.extend(js.into_iter().map(|j| (i, j)));
+        }
+        let mut graph = String::new();
+        writeln!(graph, "digraph G {{").unwrap();
+        writeln!(graph, "node [ordering=out];").unwrap();
+        for (i, node) in nodes.into_iter().enumerate() {
+            writeln!(graph, "{i} [label={node:?}];").unwrap();
+        }
+        for (start, end) in edges {
+            writeln!(graph, "{start} -> {end};",).unwrap();
+        }
+        writeln!(graph, "}}").unwrap();
+        graph
+    }
+}

--- a/src/peg/tests.rs
+++ b/src/peg/tests.rs
@@ -3,7 +3,6 @@ use crate::peg::{PegBody, PegFunction};
 use crate::rvsdg::{from_cfg::cfg_func_to_rvsdg, Expr, Id};
 use crate::util::parse_from_string;
 use bril_rs::{ConstOps, Literal, Type, ValueOps};
-use petgraph::dot::{Config, Dot};
 use std::fs::File;
 use std::io::Write;
 
@@ -78,9 +77,8 @@ impl PegTest {
 }
 
 fn output_dot_graph(name: &str, peg: &PegFunction) {
-    let contents = format!("{}", Dot::with_config(&peg.graph(), &[Config::EdgeNoLabel]));
     let mut file = File::create(name).unwrap();
-    file.write_all(contents.as_bytes()).unwrap();
+    file.write_all(peg.graph().as_bytes()).unwrap();
 }
 
 #[test]


### PR DESCRIPTION
This PR:
- Adds a PegProgram struct to mirror RVSDGs.
- Makes PegFunction::graph preserve orderings of its children (there's an ordering attribute).
- Adds pegs to the DebugVisualization struct. I think I did this right, but RVSDG viz wasn't working on the files I tested, and so PEG viz didn't work either.