### PR TITLE
bump egglog revision

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ name = "files"
 
 
 [dependencies]
-egglog = { git = "https://github.com/egraphs-good/egglog", rev = "c83fc75" }
+egglog = { git = "https://github.com/egraphs-good/egglog", rev = "8cd5fda" }
 log = "0.4.19"
 thiserror = "1"
 lalrpop-util = { version = "0.19.8", features = ["lexer"] }


### PR DESCRIPTION
Larger diff because this changed the peg visualizations. Spot-checks look reasonable.