### PR TITLE
PEG Interpreter Memoization

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -18,11 +18,6 @@ struct Args {
     #[clap(long)]
     interp: bool,
 
-    /// Translate the input program to a PEG and run it.
-    /// Throws an error if used with the interp flag.
-    #[clap(long)]
-    peg_interp: bool,
-
     /// Path that eggcc will put interp profile results
     #[clap(long)]
     profile_out: Option<PathBuf>,
@@ -52,22 +47,10 @@ fn main() {
         return;
     }
 
-    let run = if args.peg_interp {
-        if args.interp {
-            eprintln!("--peg-interp is not compatible with --interp");
-            return;
-        }
-        Run {
-            prog_with_args: TestProgram::File(args.file.clone()).read_program(),
-            test_type: RunType::PegConversion,
-            interp: true,
-        }
-    } else {
-        Run {
-            prog_with_args: TestProgram::File(args.file.clone()).read_program(),
-            test_type: args.run_mode,
-            interp: args.interp,
-        }
+    let run = Run {
+        prog_with_args: TestProgram::File(args.file.clone()).read_program(),
+        test_type: args.run_mode,
+        interp: args.interp,
     };
 
     let result = run.run();

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,11 @@ struct Args {
     #[clap(long)]
     interp: bool,
 
+    /// Translate the input program to a PEG and run it.
+    /// Throws an error if used with the interp flag.
+    #[clap(long)]
+    peg_interp: bool,
+
     /// Path that eggcc will put interp profile results
     #[clap(long)]
     profile_out: Option<PathBuf>,
@@ -47,10 +52,22 @@ fn main() {
         return;
     }
 
-    let run = Run {
-        prog_with_args: TestProgram::File(args.file.clone()).read_program(),
-        test_type: args.run_mode,
-        interp: args.interp,
+    let run = if args.peg_interp {
+        if args.interp {
+            eprintln!("--peg-interp is not compatible with --interp");
+            return;
+        }
+        Run {
+            prog_with_args: TestProgram::File(args.file.clone()).read_program(),
+            test_type: RunType::PegConversion,
+            interp: true,
+        }
+    } else {
+        Run {
+            prog_with_args: TestProgram::File(args.file.clone()).read_program(),
+            test_type: args.run_mode,
+            interp: args.interp,
+        }
     };
 
     let result = run.run();

--- a/tests/small/fib_shape.bril
+++ b/tests/small/fib_shape.bril
@@ -1,4 +1,4 @@
-# ARGS: 9
+# ARGS: 8
 @main(input: int) {
   one: int = const 1;
   i: int = const 0;

--- a/tests/small/fib_shape.bril
+++ b/tests/small/fib_shape.bril
@@ -1,4 +1,4 @@
-# ARGS: 3
+# ARGS: 9
 @main(input: int) {
   one: int = const 1;
   i: int = const 0;

--- a/tests/small/fib_shape.bril
+++ b/tests/small/fib_shape.bril
@@ -1,4 +1,4 @@
-# ARGS: 8
+# ARGS: 10
 @main(input: int) {
   one: int = const 1;
   i: int = const 0;


### PR DESCRIPTION
This PR cleans up and then speeds up the PEG interpreter. It is now fast enough to run the fib-shape test with n=10 as part of the test suite. It's still honestly not that fast, but I don't think it needs to be faster than it is now for the foreseeable future.