### PR TITLE
Rename RvsdgExpr to BasicExpr

### DIFF
--- a/src/peg/mod.rs
+++ b/src/peg/mod.rs
@@ -10,7 +10,7 @@
 pub(crate) mod peg2dot;
 pub(crate) mod simulate;
 
-use crate::rvsdg::{Id, Operand, RvsdgBody, RvsdgExpr, RvsdgFunction, RvsdgProgram};
+use crate::rvsdg::{BasicExpr, Id, Operand, RvsdgBody, RvsdgFunction, RvsdgProgram};
 use std::collections::HashMap;
 
 #[cfg(test)]
@@ -20,7 +20,7 @@ mod tests;
 #[derive(Debug, PartialEq)]
 pub(crate) enum PegBody {
     /// A basic expression.
-    BasicOp(RvsdgExpr<Id>),
+    BasicOp(BasicExpr<Id>),
     /// An argument of the enclosing function.
     Arg(usize),
     /// An if statement..
@@ -125,21 +125,21 @@ impl PegBuilder<'_> {
                     // To translate a BasicOp, translate all its arguments, then change ops to ids
                     RvsdgBody::BasicOp(expr) => {
                         let expr = match expr {
-                            RvsdgExpr::Op(op, xs, ty) => RvsdgExpr::Op(
+                            BasicExpr::Op(op, xs, ty) => BasicExpr::Op(
                                 *op,
                                 xs.iter().map(|x| self.get_pegs(*x, scope)).collect(),
                                 ty.clone(),
                             ),
-                            RvsdgExpr::Call(f, xs, num_outputs, ty) => RvsdgExpr::Call(
+                            BasicExpr::Call(f, xs, num_outputs, ty) => BasicExpr::Call(
                                 f.clone(),
                                 xs.iter().map(|x| self.get_pegs(*x, scope)).collect(),
                                 *num_outputs,
                                 ty.clone(),
                             ),
-                            RvsdgExpr::Print(xs) => RvsdgExpr::Print(
+                            BasicExpr::Print(xs) => BasicExpr::Print(
                                 xs.iter().map(|x| self.get_pegs(*x, scope)).collect(),
                             ),
-                            RvsdgExpr::Const(o, t, l) => RvsdgExpr::Const(*o, t.clone(), l.clone()),
+                            BasicExpr::Const(o, t, l) => BasicExpr::Const(*o, t.clone(), l.clone()),
                         };
                         assert_eq!(0, selected);
                         let out = self.pegs.len();

--- a/src/peg/peg2dot.rs
+++ b/src/peg/peg2dot.rs
@@ -1,7 +1,7 @@
 //! Render a PEG into Dot format;
 
 use crate::peg::{PegBody, PegFunction, PegProgram};
-use crate::rvsdg::RvsdgExpr;
+use crate::rvsdg::BasicExpr;
 use bril_rs::ConstOps;
 use std::fmt::Write;
 
@@ -34,19 +34,19 @@ impl PegFunction {
             let node = match node {
                 PegBody::Arg(arg) => format!("arg {arg}"),
                 PegBody::BasicOp(expr) => match expr {
-                    RvsdgExpr::Op(f, xs, _ty) => {
+                    BasicExpr::Op(f, xs, _ty) => {
                         js = xs.to_vec();
                         format!("{f}")
                     }
-                    RvsdgExpr::Call(f, xs, _, _) => {
+                    BasicExpr::Call(f, xs, _, _) => {
                         js = xs.to_vec();
                         format!("{f}")
                     }
-                    RvsdgExpr::Print(xs) => {
+                    BasicExpr::Print(xs) => {
                         js = xs.to_vec();
                         "PRINT".into()
                     }
-                    RvsdgExpr::Const(ConstOps::Const, _, literal) => {
+                    BasicExpr::Const(ConstOps::Const, _, literal) => {
                         format!("{literal}")
                     }
                 },

--- a/src/peg/simulate.rs
+++ b/src/peg/simulate.rs
@@ -2,7 +2,7 @@
 
 use crate::cfg::Identifier;
 use crate::peg::{PegBody, PegProgram};
-use crate::rvsdg::RvsdgExpr;
+use crate::rvsdg::BasicExpr;
 use bril_rs::{ConstOps, Literal, ValueOps};
 use std::cell::RefCell;
 use std::collections::HashMap;
@@ -88,7 +88,7 @@ impl Simulator<'_> {
         }
         let out = match &self.program.functions[self.func].nodes[body_index] {
             PegBody::BasicOp(expr) => match expr {
-                RvsdgExpr::Op(op, xs, _ty) => {
+                BasicExpr::Op(op, xs, _ty) => {
                     let xs: Vec<_> = xs.iter().map(|x| self.simulate_body(*x)).collect();
                     match op {
                         ValueOps::Add => {
@@ -106,7 +106,7 @@ impl Simulator<'_> {
                         op => todo!("implement {op}"),
                     }
                 }
-                RvsdgExpr::Call(f, xs, _, _) => {
+                BasicExpr::Call(f, xs, _, _) => {
                     let Identifier::Name(f) = f else {
                         panic!("function call identifier should be a name");
                     };
@@ -127,7 +127,7 @@ impl Simulator<'_> {
                             .unwrap(),
                     )
                 }
-                RvsdgExpr::Print(xs) => {
+                BasicExpr::Print(xs) => {
                     for x in xs {
                         let value = self.simulate_body(*x);
                         // if not a print edge
@@ -137,7 +137,7 @@ impl Simulator<'_> {
                     }
                     None
                 }
-                RvsdgExpr::Const(ConstOps::Const, literal, _) => Some(literal.clone()),
+                BasicExpr::Const(ConstOps::Const, literal, _) => Some(literal.clone()),
             },
             PegBody::Arg(arg) => {
                 if *arg == self.args.len() {

--- a/src/peg/tests.rs
+++ b/src/peg/tests.rs
@@ -1,7 +1,7 @@
 use crate::cfg::program_to_cfg;
 use crate::peg::{PegBody, PegFunction, PegProgram};
 use crate::rvsdg::cfg_to_rvsdg;
-use crate::rvsdg::{Id, RvsdgExpr};
+use crate::rvsdg::{BasicExpr, Id};
 use crate::util::parse_from_string;
 use bril_rs::{ConstOps, Literal, Type, ValueOps};
 
@@ -33,7 +33,7 @@ impl PegTest {
     }
 
     fn lit_int(&mut self, i: i64) -> Id {
-        self.make_node(PegBody::BasicOp(RvsdgExpr::Const(
+        self.make_node(PegBody::BasicOp(BasicExpr::Const(
             ConstOps::Const,
             Literal::Int(i),
             Type::Int,
@@ -41,7 +41,7 @@ impl PegTest {
     }
 
     fn lt(&mut self, l: Id, r: Id) -> Id {
-        self.make_node(PegBody::BasicOp(RvsdgExpr::Op(
+        self.make_node(PegBody::BasicOp(BasicExpr::Op(
             ValueOps::Lt,
             vec![l, r],
             Type::Bool,
@@ -49,7 +49,7 @@ impl PegTest {
     }
 
     fn add(&mut self, l: Id, r: Id, ty: Type) -> Id {
-        self.make_node(PegBody::BasicOp(RvsdgExpr::Op(
+        self.make_node(PegBody::BasicOp(BasicExpr::Op(
             ValueOps::Add,
             vec![l, r],
             ty,
@@ -57,7 +57,7 @@ impl PegTest {
     }
 
     fn mul(&mut self, l: Id, r: Id, ty: Type) -> Id {
-        self.make_node(PegBody::BasicOp(RvsdgExpr::Op(
+        self.make_node(PegBody::BasicOp(BasicExpr::Op(
             ValueOps::Mul,
             vec![l, r],
             ty,
@@ -85,7 +85,7 @@ impl PegTest {
     }
 
     fn print(&mut self, xs: Vec<Id>) -> Id {
-        self.make_node(PegBody::BasicOp(RvsdgExpr::Print(xs)))
+        self.make_node(PegBody::BasicOp(BasicExpr::Print(xs)))
     }
 
     fn make_node(&mut self, body: PegBody) -> Id {

--- a/src/rvsdg/from_cfg.rs
+++ b/src/rvsdg/from_cfg.rs
@@ -21,7 +21,7 @@ use crate::rvsdg::Result;
 use super::live_variables::{live_variables, Names};
 use super::{
     live_variables::{LiveVariableAnalysis, VarId},
-    Id, Operand, RvsdgBody, RvsdgError, RvsdgExpr,
+    BasicExpr, Id, Operand, RvsdgBody, RvsdgError,
 };
 use super::{RvsdgFunction, RvsdgType};
 
@@ -193,7 +193,7 @@ impl<'a> RvsdgBuilder<'a> {
                 // Predicate is just "true"
                 Operand::Id(get_id(
                     &mut self.expr,
-                    RvsdgBody::BasicOp(RvsdgExpr::Const(
+                    RvsdgBody::BasicOp(BasicExpr::Const(
                         ConstOps::Const,
                         Literal::Bool(true),
                         Type::Bool,
@@ -214,7 +214,7 @@ impl<'a> RvsdgBuilder<'a> {
                     // We need to negate the operand
                     Operand::Id(get_id(
                         &mut self.expr,
-                        RvsdgBody::BasicOp(RvsdgExpr::Op(ValueOps::Not, vec![op], Type::Bool)),
+                        RvsdgBody::BasicOp(BasicExpr::Op(ValueOps::Not, vec![op], Type::Bool)),
                     ))
                 } else {
                     op
@@ -389,7 +389,7 @@ impl<'a> RvsdgBuilder<'a> {
                     let dest_var = self.analysis.intern.intern(dest);
                     let const_id = get_id(
                         &mut self.expr,
-                        RvsdgBody::BasicOp(RvsdgExpr::Const(
+                        RvsdgBody::BasicOp(BasicExpr::Const(
                             *op,
                             value.clone(),
                             const_type.clone(),
@@ -428,7 +428,7 @@ impl<'a> RvsdgBuilder<'a> {
                         let mut ops = convert_args(args, &mut self.analysis, &mut self.store, pos)?;
                         ops.push(self.store[&self.analysis.state_var]);
                         let expr =
-                            RvsdgExpr::Call((&funcs[0]).into(), ops, 2, Some(op_type.clone()));
+                            BasicExpr::Call((&funcs[0]).into(), ops, 2, Some(op_type.clone()));
                         let expr_id = get_id(&mut self.expr, RvsdgBody::BasicOp(expr));
                         self.store.insert(dest_var, Operand::Id(expr_id));
                         self.store
@@ -437,7 +437,7 @@ impl<'a> RvsdgBuilder<'a> {
                     _ => {
                         let dest_var = self.analysis.intern.intern(dest);
                         let ops = convert_args(args, &mut self.analysis, &mut self.store, pos)?;
-                        let expr = RvsdgExpr::Op(*op, ops, op_type.clone());
+                        let expr = BasicExpr::Op(*op, ops, op_type.clone());
                         let expr_id = get_id(&mut self.expr, RvsdgBody::BasicOp(expr));
                         self.store.insert(dest_var, Operand::Id(expr_id));
                     }
@@ -454,7 +454,7 @@ impl<'a> RvsdgBuilder<'a> {
                 } => {
                     let mut ops = convert_args(args, &mut self.analysis, &mut self.store, pos)?;
                     ops.push(self.store[&self.analysis.state_var]);
-                    let expr = RvsdgExpr::Call(
+                    let expr = BasicExpr::Call(
                         (&funcs[0]).into(),
                         ops,
                         1,
@@ -476,7 +476,7 @@ impl<'a> RvsdgBuilder<'a> {
                 } => {
                     let mut ops = convert_args(args, &mut self.analysis, &mut self.store, pos)?;
                     ops.push(self.store[&self.analysis.state_var]);
-                    let expr = RvsdgExpr::Print(ops);
+                    let expr = BasicExpr::Print(ops);
                     let expr_id = get_id(&mut self.expr, RvsdgBody::BasicOp(expr));
                     self.store
                         .insert(self.analysis.state_var, Operand::Id(expr_id));
@@ -503,7 +503,7 @@ impl<'a> RvsdgBuilder<'a> {
                 Annotation::AssignCond { dst, cond } => {
                     let id = get_id(
                         &mut self.expr,
-                        RvsdgBody::BasicOp(RvsdgExpr::Const(
+                        RvsdgBody::BasicOp(BasicExpr::Const(
                             ConstOps::Const,
                             Literal::Int(*cond as i64),
                             Type::Int,

--- a/src/rvsdg/mod.rs
+++ b/src/rvsdg/mod.rs
@@ -86,7 +86,7 @@ pub(crate) type Result<T = ()> = std::result::Result<T, RvsdgError>;
 pub(crate) type Id = usize;
 
 #[derive(Debug, PartialEq, Clone)]
-pub(crate) enum RvsdgExpr<Op> {
+pub(crate) enum BasicExpr<Op> {
     /// A primitive operation.
     Op(ValueOps, Vec<Op>, Type),
     /// A function call. The last parameter is the number of outputs to the
@@ -118,7 +118,7 @@ pub(crate) enum Operand {
 
 #[derive(Debug, PartialEq, Clone)]
 pub(crate) enum RvsdgBody {
-    BasicOp(RvsdgExpr<Operand>),
+    BasicOp(BasicExpr<Operand>),
 
     /// Conditional branch, where the outputs chosen depend on the predicate.
     Gamma {

--- a/src/rvsdg/to_cfg.rs
+++ b/src/rvsdg/to_cfg.rs
@@ -25,7 +25,7 @@ use crate::{
     util::FreshNameGen,
 };
 
-use super::{Id, Operand, RvsdgBody, RvsdgExpr, RvsdgFunction, RvsdgProgram, RvsdgType};
+use super::{BasicExpr, Id, Operand, RvsdgBody, RvsdgFunction, RvsdgProgram, RvsdgType};
 
 enum IncompleteBranch {
     /// Conditional jump from a given block to the next one
@@ -494,12 +494,12 @@ impl<'a> RvsdgToCfg<'a> {
     // as is the case when printing.
     fn expr_to_bril(
         &mut self,
-        expr: &RvsdgExpr<Operand>,
+        expr: &BasicExpr<Operand>,
         current_args: &Vec<RvsdgValue>,
         ctx: &Option<Id>,
     ) -> RvsdgValue {
         match expr {
-            RvsdgExpr::Op(value_op, operands, ty) => {
+            BasicExpr::Op(value_op, operands, ty) => {
                 let operands = operands
                     .iter()
                     .map(|op| self.operand_to_bril(*op, current_args, ctx).unwrap_name())
@@ -516,10 +516,10 @@ impl<'a> RvsdgToCfg<'a> {
                 });
                 RvsdgValue::BrilValue(name, ty.clone())
             }
-            RvsdgExpr::Call(_name, _operands, _output_ports, _return_type_maybe) => {
+            BasicExpr::Call(_name, _operands, _output_ports, _return_type_maybe) => {
                 panic!("Not supported yet");
             }
-            RvsdgExpr::Const(_const_op, lit, ty) => {
+            BasicExpr::Const(_const_op, lit, ty) => {
                 let dest = self.get_fresh();
                 self.current_instrs.push(Instruction::Constant {
                     dest: dest.clone(),
@@ -530,7 +530,7 @@ impl<'a> RvsdgToCfg<'a> {
                 });
                 RvsdgValue::BrilValue(dest, ty.clone())
             }
-            RvsdgExpr::Print(print_operands) => {
+            BasicExpr::Print(print_operands) => {
                 assert!(print_operands.len() == 2);
                 let operands = vec![self
                     .operand_to_bril(print_operands[0], current_args, ctx)

--- a/src/rvsdg/to_egglog.rs
+++ b/src/rvsdg/to_egglog.rs
@@ -2,7 +2,7 @@ use bril_rs::{ConstOps, Literal, Type};
 use egglog::ast::{Expr, Symbol};
 use ordered_float::OrderedFloat;
 
-use super::{Operand, RvsdgBody, RvsdgExpr, RvsdgFunction, RvsdgType};
+use super::{BasicExpr, Operand, RvsdgBody, RvsdgFunction, RvsdgType};
 
 impl RvsdgFunction {
     pub(crate) fn result_val(&self) -> Option<&Operand> {
@@ -31,7 +31,7 @@ impl RvsdgFunction {
         }
     }
 
-    fn expr_to_egglog_expr(&self, expr: &RvsdgExpr<Operand>) -> Expr {
+    fn expr_to_egglog_expr(&self, expr: &BasicExpr<Operand>) -> Expr {
         use egglog::ast::{Expr::*, Literal::*};
         let f = |operands: &Vec<Operand>, ty: Option<Type>| {
             let mut res = Vec::with_capacity(operands.len() + ty.is_some() as usize);
@@ -43,15 +43,15 @@ impl RvsdgFunction {
         };
 
         match expr {
-            RvsdgExpr::Op(op, operands, ty) => {
+            BasicExpr::Op(op, operands, ty) => {
                 Call(op.to_string().into(), f(operands, Some(ty.clone())))
             }
             // TODO I'm pretty sure this conversion isn't right
-            RvsdgExpr::Call(ident, operands, _, ty) => {
+            BasicExpr::Call(ident, operands, _, ty) => {
                 Call(ident.to_string().into(), f(operands, ty.clone()))
             }
-            RvsdgExpr::Print(operands) => Call("PRINT".into(), f(operands, None)),
-            RvsdgExpr::Const(ConstOps::Const, lit, ty) => {
+            BasicExpr::Print(operands) => Call("PRINT".into(), f(operands, None)),
+            BasicExpr::Const(ConstOps::Const, lit, ty) => {
                 let lit = match (ty, lit) {
                     (Type::Int, Literal::Int(n)) => Call("Num".into(), vec![Lit(Int(*n))]),
                     (Type::Bool, Literal::Bool(b)) => {


### PR DESCRIPTION
`RvsdgExpr` is also used in pegs, so it's a bad name
I don't like `Expr` because it conflicts with bril