### PR TITLE
Supporting multiple functions (Part I): fixing function calls in egglog's encoding of RVSDG

### DIFF
--- a/src/cfg/tests.rs
+++ b/src/cfg/tests.rs
@@ -71,30 +71,30 @@ cfg_test!(
     ]
 );
 
-cfg_test!(
-    queen,
-    include_str!("../../tests/small/failing/queens-func.bril"),
-    [
-        ENTRY = (Cond { arg: "ret_cond".into(), val: true.into() }) => "next.ret",
-        ENTRY = (Cond { arg: "ret_cond".into(), val: false.into() }) => "for.cond",
-        "for.cond" = (Cond { arg: "for_cond_0".into(), val: true.into() }) => "for.body",
-        "for.cond" = (Cond { arg: "for_cond_0".into(), val: false.into() }) => "next.ret.1",
-        "for.body" = (Cond { arg: "is_valid".into(), val: true.into() }) => "rec.func",
-        "for.body" = (Cond { arg: "is_valid".into(), val: false.into() }) => "next.loop",
-        "rec.func" = (Jmp) => "next.loop",
-        "next.loop" = (Jmp) => "for.cond",
-        "next.ret" = (Jmp) => EXIT,
-        "next.ret.1" = (Jmp) => EXIT,
-    ]
-);
+// cfg_test!(
+//     queen,
+//     include_str!("../../tests/small/failing/queens-func.bril"),
+//     [
+//         ENTRY = (Cond { arg: "ret_cond".into(), val: true.into() }) => "next.ret",
+//         ENTRY = (Cond { arg: "ret_cond".into(), val: false.into() }) => "for.cond",
+//         "for.cond" = (Cond { arg: "for_cond_0".into(), val: true.into() }) => "for.body",
+//         "for.cond" = (Cond { arg: "for_cond_0".into(), val: false.into() }) => "next.ret.1",
+//         "for.body" = (Cond { arg: "is_valid".into(), val: true.into() }) => "rec.func",
+//         "for.body" = (Cond { arg: "is_valid".into(), val: false.into() }) => "next.loop",
+//         "rec.func" = (Jmp) => "next.loop",
+//         "next.loop" = (Jmp) => "for.cond",
+//         "next.ret" = (Jmp) => EXIT,
+//         "next.ret.1" = (Jmp) => EXIT,
+//     ]
+// );
 
-cfg_test!(
-    implicit_return,
-    include_str!("../../tests/small/failing/implicit-return.bril"),
-    [
-        ENTRY = (Jmp) => EXIT,
-    ]
-);
+// cfg_test!(
+//     implicit_return,
+//     include_str!("../../tests/small/failing/implicit-return.bril"),
+//     [
+//         ENTRY = (Jmp) => EXIT,
+//     ]
+// );
 
 cfg_test!(
     diamond,
@@ -108,20 +108,20 @@ cfg_test!(
     ]
 );
 
-cfg_test!(
-    block_diamond,
-    include_str!("../../tests/small/failing/block-diamond.bril"),
-    [
-        ENTRY = (Cond { arg: "a_cond".into(), val: true.into() }) => "B",
-        ENTRY = (Cond { arg: "a_cond".into(), val: false.into() }) => "D",
-        "B"   = (Cond { arg: "b_cond".into(), val: true.into() }) => "C",
-        "B"   = (Cond { arg: "b_cond".into(), val: false.into() }) => "E",
-        "C" = (Jmp) => "F",
-        "D" = (Jmp) => "E",
-        "E" = (Jmp) => "F",
-        "F" = (Jmp) => EXIT,
-    ]
-);
+// cfg_test!(
+//     block_diamond,
+//     include_str!("../../tests/small/failing/block-diamond.bril"),
+//     [
+//         ENTRY = (Cond { arg: "a_cond".into(), val: true.into() }) => "B",
+//         ENTRY = (Cond { arg: "a_cond".into(), val: false.into() }) => "D",
+//         "B"   = (Cond { arg: "b_cond".into(), val: true.into() }) => "C",
+//         "B"   = (Cond { arg: "b_cond".into(), val: false.into() }) => "E",
+//         "C" = (Jmp) => "F",
+//         "D" = (Jmp) => "E",
+//         "E" = (Jmp) => "F",
+//         "F" = (Jmp) => EXIT,
+//     ]
+// );
 
 cfg_test!(
     unstructured,

--- a/src/cfg/tests.rs
+++ b/src/cfg/tests.rs
@@ -71,30 +71,30 @@ cfg_test!(
     ]
 );
 
-// cfg_test!(
-//     queen,
-//     include_str!("../../tests/small/failing/queens-func.bril"),
-//     [
-//         ENTRY = (Cond { arg: "ret_cond".into(), val: true.into() }) => "next.ret",
-//         ENTRY = (Cond { arg: "ret_cond".into(), val: false.into() }) => "for.cond",
-//         "for.cond" = (Cond { arg: "for_cond_0".into(), val: true.into() }) => "for.body",
-//         "for.cond" = (Cond { arg: "for_cond_0".into(), val: false.into() }) => "next.ret.1",
-//         "for.body" = (Cond { arg: "is_valid".into(), val: true.into() }) => "rec.func",
-//         "for.body" = (Cond { arg: "is_valid".into(), val: false.into() }) => "next.loop",
-//         "rec.func" = (Jmp) => "next.loop",
-//         "next.loop" = (Jmp) => "for.cond",
-//         "next.ret" = (Jmp) => EXIT,
-//         "next.ret.1" = (Jmp) => EXIT,
-//     ]
-// );
+cfg_test!(
+    queen,
+    include_str!("../../tests/small/failing/queens-func.bril"),
+    [
+        ENTRY = (Cond { arg: "ret_cond".into(), val: true.into() }) => "next.ret",
+        ENTRY = (Cond { arg: "ret_cond".into(), val: false.into() }) => "for.cond",
+        "for.cond" = (Cond { arg: "for_cond_0".into(), val: true.into() }) => "for.body",
+        "for.cond" = (Cond { arg: "for_cond_0".into(), val: false.into() }) => "next.ret.1",
+        "for.body" = (Cond { arg: "is_valid".into(), val: true.into() }) => "rec.func",
+        "for.body" = (Cond { arg: "is_valid".into(), val: false.into() }) => "next.loop",
+        "rec.func" = (Jmp) => "next.loop",
+        "next.loop" = (Jmp) => "for.cond",
+        "next.ret" = (Jmp) => EXIT,
+        "next.ret.1" = (Jmp) => EXIT,
+    ]
+);
 
-// cfg_test!(
-//     implicit_return,
-//     include_str!("../../tests/small/failing/implicit-return.bril"),
-//     [
-//         ENTRY = (Jmp) => EXIT,
-//     ]
-// );
+cfg_test!(
+    implicit_return,
+    include_str!("../../tests/small/failing/implicit-return.bril"),
+    [
+        ENTRY = (Jmp) => EXIT,
+    ]
+);
 
 cfg_test!(
     diamond,
@@ -108,20 +108,20 @@ cfg_test!(
     ]
 );
 
-// cfg_test!(
-//     block_diamond,
-//     include_str!("../../tests/small/failing/block-diamond.bril"),
-//     [
-//         ENTRY = (Cond { arg: "a_cond".into(), val: true.into() }) => "B",
-//         ENTRY = (Cond { arg: "a_cond".into(), val: false.into() }) => "D",
-//         "B"   = (Cond { arg: "b_cond".into(), val: true.into() }) => "C",
-//         "B"   = (Cond { arg: "b_cond".into(), val: false.into() }) => "E",
-//         "C" = (Jmp) => "F",
-//         "D" = (Jmp) => "E",
-//         "E" = (Jmp) => "F",
-//         "F" = (Jmp) => EXIT,
-//     ]
-// );
+cfg_test!(
+    block_diamond,
+    include_str!("../../tests/small/failing/block-diamond.bril"),
+    [
+        ENTRY = (Cond { arg: "a_cond".into(), val: true.into() }) => "B",
+        ENTRY = (Cond { arg: "a_cond".into(), val: false.into() }) => "D",
+        "B"   = (Cond { arg: "b_cond".into(), val: true.into() }) => "C",
+        "B"   = (Cond { arg: "b_cond".into(), val: false.into() }) => "E",
+        "C" = (Jmp) => "F",
+        "D" = (Jmp) => "E",
+        "E" = (Jmp) => "F",
+        "F" = (Jmp) => EXIT,
+    ]
+);
 
 cfg_test!(
     unstructured,

--- a/src/peg/peg2dot.rs
+++ b/src/peg/peg2dot.rs
@@ -40,7 +40,7 @@ impl PegFunction {
                     }
                     BasicExpr::Call(f, xs, _, _) => {
                         js = xs.to_vec();
-                        format!("{f}")
+                        f.to_string()
                     }
                     BasicExpr::Print(xs) => {
                         js = xs.to_vec();

--- a/src/peg/simulate.rs
+++ b/src/peg/simulate.rs
@@ -1,6 +1,5 @@
 //! This module lets you interpret a PEG.
 
-use crate::cfg::Identifier;
 use crate::peg::{PegBody, PegProgram};
 use crate::rvsdg::BasicExpr;
 use bril_rs::{ConstOps, Literal, ValueOps};
@@ -107,9 +106,6 @@ impl Simulator<'_> {
                     }
                 }
                 BasicExpr::Call(f, xs, _, _) => {
-                    let Identifier::Name(f) = f else {
-                        panic!("function call identifier should be a name");
-                    };
                     let args: Vec<_> = xs
                         .iter()
                         .map(|x| self.simulate_body(*x))

--- a/src/rvsdg/egglog_optimizer/schema.egg
+++ b/src/rvsdg/egglog_optimizer/schema.egg
@@ -20,6 +20,9 @@
     (Bril Type)
     (PrintState))
 (sort FuncSigs (Vec EffectType))
+(datatype OptionType
+    (SomeType Type)
+    (NoneType))
 ;; Literal
 (function Num (i64) Literal)
 (function Float (f64) Literal)
@@ -28,10 +31,14 @@
 ;; Expr
 (datatype ConstOps (const))
 (function Const (Type ConstOps Literal) Expr)
-(function Call (Type String VecOperand) Expr)
+;; Call takes n + 1 arguments, where the last one is the state edge.
+;; It returns {1, 2} values, where the first one is a state edge and 
+;; the second one (optional) is the actual return value.
+(function Call (OptionType String VecOperand) Expr)
 (function add (Type Operand Operand) Expr)
 (function sub (Type Operand Operand) Expr)
 (function mul (Type Operand Operand) Expr)
+(function fmul (Type Operand Operand) Expr)
 (function div (Type Operand Operand) Expr)
 (function eq (Type Operand Operand) Expr)
 (function lt (Type Operand Operand) Expr)
@@ -70,10 +77,6 @@
 ;;     i += 1
 ;;   while(i < n);
 ;;   return ansm
-
-
-
-
 
 ;; ;; inputs: [n]
 ; (Project 0

--- a/src/rvsdg/from_cfg.rs
+++ b/src/rvsdg/from_cfg.rs
@@ -430,9 +430,9 @@ impl<'a> RvsdgBuilder<'a> {
                         let expr =
                             BasicExpr::Call((&funcs[0]).into(), ops, 2, Some(op_type.clone()));
                         let expr_id = get_id(&mut self.expr, RvsdgBody::BasicOp(expr));
-                        self.store.insert(dest_var, Operand::Id(expr_id));
+                        self.store.insert(dest_var, Operand::Project(1, expr_id));
                         self.store
-                            .insert(self.analysis.state_var, Operand::Project(1, expr_id));
+                            .insert(self.analysis.state_var, Operand::Project(0, expr_id));
                     }
                     _ => {
                         let dest_var = self.analysis.intern.intern(dest);

--- a/src/rvsdg/mod.rs
+++ b/src/rvsdg/mod.rs
@@ -100,7 +100,7 @@ pub(crate) enum BasicExpr<Op> {
     /// Essentially all of the code here does not use this value at all. The
     /// exception is the SVG rendering code, which relies on this value to
     /// determine how many output ports to add to a function call.
-    Call(Identifier, Vec<Op>, usize, Option<Type>),
+    Call(String, Vec<Op>, usize, Option<Type>),
     /// A literal constant.
     Const(ConstOps, Literal, Type),
     /// Following bril, we treat 'print' as a built-in primitive, rather than
@@ -229,6 +229,7 @@ impl RvsdgProgram {
             let name = fresh_names.fresh();
             func_names.push(name.clone());
             let expr = function.to_egglog_expr();
+            println!("{}", &expr);
             res_string.push(format!("(let {} {})", name, expr));
         }
 

--- a/src/rvsdg/tests.rs
+++ b/src/rvsdg/tests.rs
@@ -2,7 +2,7 @@ use bril_rs::{ConstOps, Literal, Type, ValueOps};
 use egglog::EGraph;
 
 use crate::{
-    cfg::{program_to_cfg, Identifier},
+    cfg::program_to_cfg,
     rvsdg::{cfg_to_rvsdg, BasicExpr, Id, Operand, RvsdgBody},
     util::parse_from_string,
 };

--- a/src/rvsdg/tests.rs
+++ b/src/rvsdg/tests.rs
@@ -76,7 +76,7 @@ impl RvsdgTest {
         )))
     }
 
-    fn void_function(&mut self, func: impl Into<Identifier>, args: &[Operand]) -> Operand {
+    fn void_function(&mut self, func: impl Into<String>, args: &[Operand]) -> Operand {
         self.make_node(RvsdgBody::BasicOp(BasicExpr::Call(
             func.into(),
             args.to_vec(),

--- a/src/rvsdg/to_egglog.rs
+++ b/src/rvsdg/to_egglog.rs
@@ -46,9 +46,14 @@ impl RvsdgFunction {
             BasicExpr::Op(op, operands, ty) => {
                 Call(op.to_string().into(), f(operands, Some(ty.clone())))
             }
-            // TODO I'm pretty sure this conversion isn't right
             BasicExpr::Call(ident, operands, _, ty) => {
-                Call(ident.to_string().into(), f(operands, ty.clone()))
+                let ident = Lit(String(ident.into()));
+                let args = Self::vec_operand(&f(operands, None));
+                let ty = match ty {
+                    Some(ty) => Call("SomeType".into(), vec![Self::expr_from_ty(ty)]),
+                    None => Call("NoneType".into(), vec![]),
+                };
+                Call("Call".into(), vec![ty, ident, args])
             }
             BasicExpr::Print(operands) => Call("PRINT".into(), f(operands, None)),
             BasicExpr::Const(ConstOps::Const, lit, ty) => {


### PR DESCRIPTION
* Function names should be a string instead of Identifier.
* Function call in RVSDG should support effects and void return type.
* fix the egglog to RVSDG conversion to have the right number of arguments.
* Function call returns {1, 2} values, where the first value is the state edge, and the second one (optional) is the actual return value.