### PR TITLE
Fix eager PEG phi node eval

### DIFF
--- a/src/peg/simulate.rs
+++ b/src/peg/simulate.rs
@@ -144,13 +144,10 @@ impl Simulator<'_> {
                 }
             }
             PegBody::Phi(c, x, y) => {
-                let c = self.simulate_body(*c);
-                let x = self.simulate_body(*x);
-                let y = self.simulate_body(*y);
-                if bool(c) {
-                    x
+                if bool(self.simulate_body(*c)) {
+                    self.simulate_body(*x)
                 } else {
-                    y
+                    self.simulate_body(*y)
                 }
             }
             PegBody::Theta(a, b, l) => {


### PR DESCRIPTION
Fixes #59.

Phi nodes were being evaluated eagerly, now they're not. 