### PR TITLE
Add RVSDG shift rules

### DIFF
--- a/src/rvsdg/egglog_optimizer/mod.rs
+++ b/src/rvsdg/egglog_optimizer/mod.rs
@@ -8,6 +8,7 @@ pub fn rvsdg_egglog_code() -> String {
     let code = vec![
         include_str!("schema.egg").to_string(),
         include_str!("subst.egg").to_string(),
+        include_str!("shift.egg").to_string(),
         constant_fold_egglog(),
     ];
     code.join("\n")

--- a/src/rvsdg/egglog_optimizer/shift.egg
+++ b/src/rvsdg/egglog_optimizer/shift.egg
@@ -1,0 +1,96 @@
+;; Shift
+(ruleset shift)
+
+;; Within e, replace all (Args x) where x > last-unshifted
+;; with (Args (x + amt))
+;;                             e             last-unshifted  amt
+(function ShiftExpr           (Expr          i64             i64) Expr)
+(function ShiftOperand        (Operand       i64             i64) Operand)
+(function ShiftBody           (Body          i64             i64) Body)
+(function ShiftVecOperand     (VecOperand    i64             i64) VecOperand)
+(function ShiftVecVecOperand  (VecVecOperand i64             i64) VecVecOperand)
+
+(rewrite (ShiftExpr (Const ty ops lit) last-unshifted amt) (Const ty ops lit) :ruleset shift)
+(rewrite (ShiftExpr (Call ty f args) last-unshifted amt) (Call ty f (ShiftVecOperand args last-unshifted amt)) :ruleset shift)
+(rewrite (ShiftExpr (add ty a b) last-unshifted amt) (add ty (ShiftOperand a last-unshifted amt) (ShiftOperand b last-unshifted amt)) :ruleset shift)
+(rewrite (ShiftExpr (sub ty a b) last-unshifted amt) (sub ty (ShiftOperand a last-unshifted amt) (ShiftOperand b last-unshifted amt)) :ruleset shift)
+(rewrite (ShiftExpr (mul ty a b) last-unshifted amt) (mul ty (ShiftOperand a last-unshifted amt) (ShiftOperand b last-unshifted amt)) :ruleset shift)
+(rewrite (ShiftExpr (div ty a b) last-unshifted amt) (div ty (ShiftOperand a last-unshifted amt) (ShiftOperand b last-unshifted amt)) :ruleset shift)
+(rewrite (ShiftExpr (eq ty a b) last-unshifted amt) (eq ty (ShiftOperand a last-unshifted amt) (ShiftOperand b last-unshifted amt)) :ruleset shift)
+(rewrite (ShiftExpr (lt ty a b) last-unshifted amt) (lt ty (ShiftOperand a last-unshifted amt) (ShiftOperand b last-unshifted amt)) :ruleset shift)
+(rewrite (ShiftExpr (gt ty a b) last-unshifted amt) (gt ty (ShiftOperand a last-unshifted amt) (ShiftOperand b last-unshifted amt)) :ruleset shift)
+(rewrite (ShiftExpr (le ty a b) last-unshifted amt) (le ty (ShiftOperand a last-unshifted amt) (ShiftOperand b last-unshifted amt)) :ruleset shift)
+(rewrite (ShiftExpr (ge ty a b) last-unshifted amt) (ge ty (ShiftOperand a last-unshifted amt) (ShiftOperand b last-unshifted amt)) :ruleset shift)
+(rewrite (ShiftExpr (not ty a b) last-unshifted amt) (not ty (ShiftOperand a last-unshifted amt) (ShiftOperand b last-unshifted amt)) :ruleset shift)
+(rewrite (ShiftExpr (and ty a b) last-unshifted amt) (and ty (ShiftOperand a last-unshifted amt) (ShiftOperand b last-unshifted amt)) :ruleset shift)
+(rewrite (ShiftExpr (or ty a b) last-unshifted amt) (or ty (ShiftOperand a last-unshifted amt) (ShiftOperand b last-unshifted amt)) :ruleset shift)
+
+(rule ((= f (ShiftOperand (Arg x) last-unshifted amt)) (<= x last-unshifted))
+      ((union f (Arg x))) :ruleset shift)
+(rule ((= f (ShiftOperand (Arg x) last-unshifted amt)) (> x last-unshifted))
+      ((union f (Arg (+ x amt)))) :ruleset shift)
+
+(rewrite (ShiftOperand (Node b) last-unshifted amt) (Node (ShiftBody b last-unshifted amt)) :ruleset shift)
+(rewrite (ShiftOperand (Project i b) last-unshifted amt) (Project i (ShiftBody b last-unshifted amt)) :ruleset shift)
+
+(rewrite (ShiftBody (PureOp e) last-unshifted amt) (PureOp (ShiftExpr e last-unshifted amt)) :ruleset shift)
+;; Shift doesn't cross regions - so we shift into the inputs but not outputs
+;; Node that a Gamma node's idx is on the outside, so it gets affected, but not
+;; a Theta node's predicate
+(rewrite (ShiftBody (Gamma pred inputs outputs) last-unshifted amt) (Gamma (ShiftOperand pred last-unshifted amt) (ShiftVecOperand inputs last-unshifted amt) outputs) :ruleset shift)
+(rewrite (ShiftBody (Theta pred inputs outputs) last-unshifted amt) (Theta pred (ShiftVecOperand inputs last-unshifted amt) outputs) :ruleset shift)
+
+;; params: vec, var, op, next index to shift
+;; rtjoa: TODO: implement by mapping internally so they're not O(n^2) time
+(function ShiftVecOperandHelper (VecOperand i64 i64 i64) VecOperand)
+(rewrite (ShiftVecOperand vec last-unshifted amt) (ShiftVecOperandHelper vec last-unshifted amt 0) :ruleset shift)
+(rule
+  (
+    (= f (ShiftVecOperandHelper (VO vec) last-unshifted amt i))
+    (< i (vec-length vec))
+  )
+  ( 
+    (union
+      (ShiftVecOperandHelper (VO vec) last-unshifted amt i)
+      (ShiftVecOperandHelper
+        (VO (vec-set vec i (ShiftOperand (vec-get vec i) last-unshifted amt)))
+        last-unshifted amt (+ i 1)
+        ))
+  ) :ruleset shift)
+
+(rule
+  (
+    (= f (ShiftVecOperandHelper (VO vec) last-unshifted amt i))
+    (= i (vec-length vec))
+  )
+  ( 
+    (union (ShiftVecOperandHelper (VO vec) last-unshifted amt i) (VO vec))
+  ) :ruleset shift)
+
+
+;; params: vec, var, op, next index to shift
+;; rtjoa: TODO: implement by mapping internally so they're not O(n^2) time
+(function ShiftVecVecOperandHelper (VecVecOperand i64 i64 i64) VecVecOperand)
+(rewrite (ShiftVecVecOperand vec last-unshifted amt) (ShiftVecVecOperandHelper vec last-unshifted amt 0) :ruleset shift)
+(rule
+  (
+    (= f (ShiftVecVecOperandHelper (VVO vec) last-unshifted amt i))
+    (< i (vec-length vec))
+  )
+  ( 
+    (union
+      (ShiftVecVecOperandHelper (VVO vec) last-unshifted amt i)
+      (ShiftVecVecOperandHelper
+        (VVO (vec-set vec i (ShiftVecOperand (vec-get vec i) last-unshifted amt)))
+        last-unshifted amt (+ i 1)
+        ))
+  ) :ruleset shift)
+
+(rule
+  (
+    (= f (ShiftVecVecOperandHelper (VVO vec) last-unshifted amt i))
+    (= i (vec-length vec))
+  )
+  ( 
+    (union (ShiftVecVecOperandHelper (VVO vec) last-unshifted amt i) (VVO vec))
+  ) :ruleset shift)

--- a/src/rvsdg/tests.rs
+++ b/src/rvsdg/tests.rs
@@ -344,8 +344,6 @@ fn rvsdg_basic_odd_branch() {
     let cfg = program_to_cfg(&prog);
     let actual = &cfg_to_rvsdg(&cfg).unwrap().functions[0];
 
-    println!("{:?}", actual);
-    println!("{}", actual.to_svg());
     assert!(deep_equal(&expected, actual));
 }
 

--- a/src/rvsdg/tests.rs
+++ b/src/rvsdg/tests.rs
@@ -343,6 +343,9 @@ fn rvsdg_basic_odd_branch() {
     let prog = parse_from_string(PROGRAM);
     let cfg = program_to_cfg(&prog);
     let actual = &cfg_to_rvsdg(&cfg).unwrap().functions[0];
+
+    println!("{:?}", actual);
+    println!("{}", actual.to_svg());
     assert!(deep_equal(&expected, actual));
 }
 
@@ -750,6 +753,105 @@ fn rvsdg_subst() {
                                                                      (const)
                                                                      (Num 2)))))))))))))
     (check (= substed expected))
+    "#;
+    let mut egraph = new_rvsdg_egraph();
+    egraph.parse_and_run_program(EGGLOG_GAMMA_PROGRAM).unwrap();
+}
+
+#[test]
+fn rvsdg_shift() {
+    const EGGLOG_PROGRAM: &str = r#"
+    (let unshifted
+              (Node (PureOp (lt (BoolT) (Node (PureOp (add (IntT) (Arg 2)
+                                                   (Node (PureOp (Const (IntT)
+                                                                        (const)
+                                                                        (Num 1)))))))
+                                (Arg 3)))))
+    (let shifted (ShiftOperand unshifted 2 4))
+    (run-schedule (saturate shift))
+    (let expected
+              (Node (PureOp (lt (BoolT) (Node (PureOp (add (IntT) (Arg 2)
+                                                   (Node (PureOp (Const (IntT)
+                                                                        (const)
+                                                                        (Num 1)))))))
+                                (Arg 7)))))
+    (check (= shifted expected))
+    "#;
+    let mut egraph = new_rvsdg_egraph();
+    egraph.parse_and_run_program(EGGLOG_PROGRAM).unwrap();
+
+    const EGGLOG_THETA_PROGRAM: &str = r#"
+    (let unshifted
+        (Theta
+              (Node (PureOp (lt (BoolT) (Node (PureOp (add (IntT) (Arg 2)
+                                                   (Node (PureOp (Const (IntT)
+                                                                        (const)
+                                                                        (Num 1)))))))
+                                (Arg 3))))
+              (VO (vec-of (Arg 0)
+                      (Node (PureOp (Const (IntT) (const) (Num 0))))
+                      (Node (PureOp (Const (IntT) (const) (Num 0))))
+                      (Arg 1)))
+              (VO (vec-of (Arg 0)
+                      (Node (PureOp (add (IntT) (Arg 1) (Arg 2))))
+                      (Node (PureOp (add (IntT) (Arg 2)
+                                         (Node (PureOp (Const (IntT) (const) (Num 1)))))))
+                      (Arg 3)))))
+    (let shifted (ShiftBody unshifted 0 10))
+    (run-schedule (saturate shift))
+    (let expected
+        (Theta
+              (Node (PureOp (lt (BoolT) (Node (PureOp (add (IntT) (Arg 2)
+                                                   (Node (PureOp (Const (IntT)
+                                                                        (const)
+                                                                        (Num 1)))))))
+                                (Arg 3))))
+              (VO (vec-of (Arg 0)
+                      (Node (PureOp (Const (IntT) (const) (Num 0))))
+                      (Node (PureOp (Const (IntT) (const) (Num 0))))
+                      (Arg 11)))
+              (VO (vec-of (Arg 0)
+                      (Node (PureOp (add (IntT) (Arg 1) (Arg 2))))
+                      (Node (PureOp (add (IntT) (Arg 2)
+                                         (Node (PureOp (Const (IntT) (const) (Num 1)))))))
+                      (Arg 3)))))
+    (check (= shifted expected))
+    "#;
+    let mut egraph = new_rvsdg_egraph();
+    egraph.parse_and_run_program(EGGLOG_THETA_PROGRAM).unwrap();
+
+    const EGGLOG_GAMMA_PROGRAM: &str = r#"
+    (let unshifted 
+        (Gamma
+         (Node
+          (PureOp
+           (lt (BoolT) (Arg 0) (Arg 1))))
+         (VO (vec-of
+          (Arg 3)
+          (Arg 0)))
+         (VVO (vec-of (VO (vec-of (Arg 0) (Arg 1)))
+                 (VO (vec-of (Arg 0)
+                             (Node (PureOp (mul (IntT) (Arg 1)
+                                                (Node (PureOp (Const (IntT)
+                                                                     (const)
+                                                                     (Num 2)))))))))))))
+    (let shifted (ShiftBody unshifted 0 10))
+    (run-schedule (saturate shift))
+    (let expected
+        (Gamma
+         (Node
+          (PureOp
+           (lt (BoolT) (Arg 0) (Arg 11))))
+         (VO (vec-of
+          (Arg 13)
+          (Arg 0)))
+         (VVO (vec-of (VO (vec-of (Arg 0) (Arg 1)))
+                 (VO (vec-of (Arg 0)
+                             (Node (PureOp (mul (IntT) (Arg 1)
+                                                (Node (PureOp (Const (IntT)
+                                                                     (const)
+                                                                     (Num 2)))))))))))))
+    (check (= shifted expected))
     "#;
     let mut egraph = new_rvsdg_egraph();
     egraph.parse_and_run_program(EGGLOG_GAMMA_PROGRAM).unwrap();


### PR DESCRIPTION
## Summary

Adds the following functions, for use in writing passes over RVSDG.
```
;; Within e, replace all (Args x) where x > last-unshifted
;; with (Args (x + amt))
;;                             e             last-unshifted  amt
(function ShiftExpr           (Expr          i64             i64) Expr)
(function ShiftOperand        (Operand       i64             i64) Operand)
(function ShiftBody           (Body          i64             i64) Body)
(function ShiftVecOperand     (VecOperand    i64             i64) VecOperand)
(function ShiftVecVecOperand  (VecVecOperand i64             i64) VecVecOperand)```
```

The rules that execute them are placed in ruleset `shift`.

## Testing

Added tests to [`src/rvsdg/tests.rs`](https://github.com/rtjoa/eggcc/blob/subst/src/rvsdg/tests.rs)