### PR TITLE
Don't interpret original program unless --interp passed

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -329,19 +329,15 @@ impl Run {
     }
 
     pub fn run(&self) -> RunOutput {
-        let original_interpreted =
-            if self.interp {
-                Some (
-                    Optimizer::interp(
-                    &self.prog_with_args.program,
-                    self.prog_with_args.args.clone(),
-                    None,
-                )
-            )
-            } else {
-                None
-            }
-        ;
+        let original_interpreted = if self.interp {
+            Some(Optimizer::interp(
+                &self.prog_with_args.program,
+                self.prog_with_args.args.clone(),
+                None,
+            ))
+        } else {
+            None
+        };
 
         let mut peg = None;
         let (visualizations, bril_out) = match self.test_type {

--- a/src/util.rs
+++ b/src/util.rs
@@ -285,7 +285,7 @@ pub struct RunOutput {
     pub visualizations: Vec<Visualization>,
     // if the result was interpreted, the stdout of interpreting it
     pub result_interpreted: Option<String>,
-    pub original_interpreted: String,
+    pub original_interpreted: Option<String>,
 }
 
 impl Run {
@@ -329,11 +329,19 @@ impl Run {
     }
 
     pub fn run(&self) -> RunOutput {
-        let original_interpreted = Optimizer::interp(
-            &self.prog_with_args.program,
-            self.prog_with_args.args.clone(),
-            None,
-        );
+        let original_interpreted =
+            if self.interp {
+                Some (
+                    Optimizer::interp(
+                    &self.prog_with_args.program,
+                    self.prog_with_args.args.clone(),
+                    None,
+                )
+            )
+            } else {
+                None
+            }
+        ;
 
         let mut peg = None;
         let (visualizations, bril_out) = match self.test_type {

--- a/tests/files.rs
+++ b/tests/files.rs
@@ -20,8 +20,8 @@ fn generate_tests(glob: &str) -> Vec<Trial> {
         trials.push(Trial::test(run.name(), move || {
             let result = run.run();
 
-            if let Some(interpreted) = result.result_interpreted {
-                assert_eq!(result.original_interpreted, interpreted);
+            if result.result_interpreted.is_some() {
+                assert_eq!(result.original_interpreted, result.result_interpreted);
             } else {
                 // only assert a snapshot if we are in the "small" folder
                 if snapshot && snapshot_configurations.contains(&run.test_type) {


### PR DESCRIPTION
This PR changes `run` to only interpret the original program if the interp flag is passed. Before, it would interpret the original program but not the result program if the interp flag was not passed.