### PR TITLE
Re-associate additions to promote constant folding

### DIFF
--- a/src/rvsdg/egglog_optimizer/mod.rs
+++ b/src/rvsdg/egglog_optimizer/mod.rs
@@ -1,8 +1,9 @@
 use bril_rs::Type;
 
-use self::{constant_fold::constant_fold_egglog, subst::subst_rules};
+use self::{constant_fold::constant_fold_egglog, reassoc::reassoc_rules, subst::subst_rules};
 
 pub(crate) mod constant_fold;
+pub(crate) mod reassoc;
 pub(crate) mod subst;
 
 pub fn rvsdg_egglog_code() -> String {
@@ -14,6 +15,7 @@ pub fn rvsdg_egglog_code() -> String {
         constant_fold_egglog(),
         include_str!("gamma_rewrites.egg").to_string(),
         include_str!("loop-optimizations.egg").to_string(),
+        reassoc_rules(),
     ];
     code.join("\n")
 }

--- a/src/rvsdg/egglog_optimizer/reassoc.rs
+++ b/src/rvsdg/egglog_optimizer/reassoc.rs
@@ -6,6 +6,7 @@
 pub(crate) fn reassoc_rules() -> String {
     let mut res = vec![];
     for op in ["badd", "bmul"] {
+        // Move constants to the left using commutativity
         res.push(format!(
             "
      (rule
@@ -14,6 +15,58 @@ pub(crate) fn reassoc_rules() -> String {
       ((union lhs ({op} (IntT) num other))))"
         ))
     }
+
+    // Make all terms have the form (+ a (+ b (+ ...)))
+    // By moving nesting to the right.
+    res.push(
+        "
+      (rule
+        ((= lhs (badd (IntT)
+                      (Node (PureOp (badd (IntT) a b)))
+                      c)))
+        ((union lhs
+                (badd (IntT)
+                      a
+                      (Node (PureOp (badd (IntT) b c)))))))
+      "
+        .to_string(),
+    );
+
+    // Move constants up the tree
+    res.push(
+        "
+        (rule
+          ((= lhs (badd (IntT)
+                        a
+                        (Node (PureOp (badd (IntT) b c)))))
+           (= b (Node (PureOp (Const (IntT) (const) (Num n1)))))            
+          )
+          ((union lhs
+             (badd (IntT)
+                   b
+                   (Node (PureOp (badd (IntT) a c))))))               
+        )
+      "
+        .to_string(),
+    );
+
+    // Constant fold two adjacent constants
+    res.push(
+        "
+      (rule
+        ((= lhs (badd (IntT)
+                      a
+                      (Node (PureOp (badd (IntT) b c)))))
+         (= a (Node (PureOp (Const (IntT) (const) (Num n1)))))
+         (= b (Node (PureOp (Const (IntT) (const) (Num n2))))))
+
+        ((union lhs
+          (badd (IntT)
+            (Node (PureOp (Const (IntT) (const) (Num (+ n1 n2)))))
+            c))))      
+      "
+        .to_string(),
+    );
 
     res.join("\n")
 }

--- a/src/rvsdg/egglog_optimizer/reassoc.rs
+++ b/src/rvsdg/egglog_optimizer/reassoc.rs
@@ -1,0 +1,19 @@
+//! This file is intended to move constants to the left
+//! for addition and multiplication, promoting constant folding
+
+// TODO: we should prune eclasses with constants to just contain the constant
+// otherwise, these rules will reassociate constants many times
+pub(crate) fn reassoc_rules() -> String {
+    let mut res = vec![];
+    for op in ["badd", "bmul"] {
+        res.push(format!(
+            "
+     (rule
+      ((= num (Node (PureOp (Const (IntT) (const) (Num n1)))))
+       (= lhs ({op} (IntT) other num)))
+      ((union lhs ({op} (IntT) num other))))"
+        ))
+    }
+
+    res.join("\n")
+}

--- a/src/rvsdg/egglog_optimizer/reassoc.rs
+++ b/src/rvsdg/egglog_optimizer/reassoc.rs
@@ -1,8 +1,10 @@
 //! This file is intended to move constants to the left
-//! for addition and multiplication, promoting constant folding
+//! for addition, promoting constant folding
 
 // TODO: we should prune eclasses with constants to just contain the constant
 // otherwise, these rules will reassociate constants many times
+// TODO: improve by also including multiplication in the normalization
+
 pub(crate) fn reassoc_rules() -> String {
     let mut res = vec![];
     for op in ["badd", "bmul"] {

--- a/tests/small/reassoc.bril
+++ b/tests/small/reassoc.bril
@@ -1,0 +1,20 @@
+# ARGS: 2 4
+@main(a: int, b: int) {
+  one: int = const 1;
+  two: int = const 2;
+  three: int = const 3;
+  four: int = const 4;
+
+
+  # a + 3
+  a2: int = add a three;
+  # b + 4
+  b4: int = add b four;
+  # (a + 3) + (b + 4)
+  a2b4: int = add a2 b4;
+
+  # 1 + a2b4
+  onea2b4: int = add one a2b4;
+
+  print onea2b4;
+}

--- a/tests/snapshots/files__implicit-return-rvsdg-optimize.snap
+++ b/tests/snapshots/files__implicit-return-rvsdg-optimize.snap
@@ -25,7 +25,7 @@ expression: visualization.result
 .__41__:
   v44: int = mul v9 v11;
   v46: int = const 1;
-  v50: int = add v10 v46;
+  v50: int = add v46 v10;
   v35: int = id v44;
   v36: int = id v46;
   v37: int = id v50;

--- a/tests/snapshots/files__reassoc-peg.snap
+++ b/tests/snapshots/files__reassoc-peg.snap
@@ -1,0 +1,31 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+digraph G {
+subgraph {
+node [ordering=out];
+v0 [label="int"];
+v1 [label="arg 0"];
+v2 [label="int"];
+v3 [label="add"];
+v4 [label="arg 1"];
+v5 [label="int"];
+v6 [label="add"];
+v7 [label="add"];
+v8 [label="add"];
+v9 [label="arg 2"];
+v10 [label="PRINT"];
+v3 -> v1;
+v3 -> v2;
+v6 -> v4;
+v6 -> v5;
+v7 -> v3;
+v7 -> v6;
+v8 -> v0;
+v8 -> v7;
+v10 -> v8;
+v10 -> v9;
+}
+}
+

--- a/tests/snapshots/files__reassoc-rvsdg-optimize.snap
+++ b/tests/snapshots/files__reassoc-rvsdg-optimize.snap
@@ -1,0 +1,11 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int, v1: int) {
+  v3: int = const 8;
+  v7: int = add v0 v1;
+  v9: int = add v3 v7;
+  print v9;
+}
+

--- a/tests/snapshots/files__reassoc-structured.snap
+++ b/tests/snapshots/files__reassoc-structured.snap
@@ -1,0 +1,18 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+main {
+block:
+ one: int = const 1;
+ two: int = const 2;
+ three: int = const 3;
+ four: int = const 4;
+ a2: int = add a three;
+ b4: int = add b four;
+ a2b4: int = add a2 b4;
+ onea2b4: int = add one a2b4;
+ print onea2b4;
+ return
+
+}


### PR DESCRIPTION
This PR re-associates additions, moving constants to the left.
Future work will include adding support for multiplication and pruning e-classes that are constant.

I think this is good enough to close #93 for our milestone.

