### PR TITLE
Exclude loop back-edges when finding join points.

### DIFF
--- a/src/rvsdg/from_cfg.rs
+++ b/src/rvsdg/from_cfg.rs
@@ -304,10 +304,16 @@ impl<'a> RvsdgBuilder<'a> {
             // Loop until we reach a join point.
             let mut curr = succ;
             loop {
+                // Join points are nodes with more than one predecessor
+                // (excluding loop back-edges).
                 if self
                     .cfg
                     .graph
                     .neighbors_directed(curr, Direction::Incoming)
+                    .filter(|neigh| {
+                        let Some(mut dom) = self.dom.dominators(*neigh) else { return true; };
+                        !dom.any(|n| n == curr)
+                    })
                     .nth(1)
                     .is_some()
                 {
@@ -333,7 +339,6 @@ impl<'a> RvsdgBuilder<'a> {
             } else {
                 next = Some(curr);
             }
-            // self.store = snapshot.clone();
         }
 
         let next = next.unwrap();

--- a/tests/small/flatten_loop.bril
+++ b/tests/small/flatten_loop.bril
@@ -1,0 +1,30 @@
+# ARGS: 10 10
+@main(N: int, M: int) {
+  one: int = const 1;
+  i: int = const 0;
+
+.outer_cond:
+  cond: bool = lt i N;
+  br cond .inner_start .done;
+
+.inner_start:
+  j: int = const 0;
+.inner_cond:
+  cond: bool = lt j M;
+  br cond .inner_body .outer_body;
+
+.inner_body:
+  i_times_m: int = mul i M;
+  plus_j: int = add i_times_m j;
+  print plus_j;
+
+  j: int = add j one;
+  jmp .inner_cond;
+
+.outer_body:
+  i: int = add i one;
+  jmp .outer_cond;
+
+.done:
+  print i;
+}

--- a/tests/snapshots/files__flatten_loop-rvsdg-optimize.snap
+++ b/tests/snapshots/files__flatten_loop-rvsdg-optimize.snap
@@ -1,0 +1,86 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int, v1: int) {
+  v4: int = const 0;
+  v6: int = const 1;
+  v10: int = id v4;
+  v11: int = id v6;
+  v12: int = id v1;
+  v13: int = id v0;
+  jmp .__15__;
+.__119__:
+  v125: int = const 1;
+  v126: bool = eq v33 v125;
+  v10: int = id v32;
+  v11: int = id v34;
+  v12: int = id v35;
+  v13: int = id v36;
+  br v126 .__15__ .__129__;
+.__108__:
+  v111: int = add v45 v46;
+  v113: int = const 1;
+  v32: int = id v111;
+  v33: int = id v113;
+  v34: int = id v46;
+  v35: int = id v48;
+  v36: int = id v49;
+  jmp .__119__;
+.__97__:
+  v104: int = const 1;
+  v105: bool = eq v72 v104;
+  v45: int = id v70;
+  v46: int = id v71;
+  v47: int = id v73;
+  v48: int = id v74;
+  v49: int = id v75;
+  br v105 .__51__ .__108__;
+.__77__:
+  v79: int = mul v45 v48;
+  v82: int = add v79 v47;
+  print v82;
+  v88: int = const 1;
+  v92: int = add v47 v46;
+  v70: int = id v45;
+  v71: int = id v46;
+  v72: int = id v88;
+  v73: int = id v92;
+  v74: int = id v48;
+  v75: int = id v49;
+  jmp .__97__;
+.__62__:
+  v65: int = const 0;
+  v70: int = id v45;
+  v71: int = id v46;
+  v72: int = id v65;
+  v73: int = id v47;
+  v74: int = id v48;
+  v75: int = id v49;
+  jmp .__97__;
+.__51__:
+  v53: bool = lt v47 v48;
+  br v53 .__77__ .__62__;
+.__38__:
+  v41: int = const 0;
+  v45: int = id v10;
+  v46: int = id v11;
+  v47: int = id v41;
+  v48: int = id v12;
+  v49: int = id v13;
+  jmp .__51__;
+.__25__:
+  v27: int = const 0;
+  v32: int = id v10;
+  v33: int = id v27;
+  v34: int = id v11;
+  v35: int = id v12;
+  v36: int = id v13;
+  jmp .__119__;
+.__15__:
+  v17: bool = lt v10 v13;
+  br v17 .__38__ .__25__;
+.__129__:
+  print v10;
+}
+

--- a/tests/snapshots/files__flatten_loop-structured.snap
+++ b/tests/snapshots/files__flatten_loop-structured.snap
@@ -1,0 +1,37 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+main {
+block:
+ one: int = const 1;
+ i: int = const 0;
+while true:
+ block:
+  block:
+   cond: bool = lt i N;
+   if cond:
+    break 2
+   else:
+    break 1
+  block:
+   print i;
+   return
+
+ block:
+  j: int = const 0;
+ while true:
+  block:
+   block:
+    cond: bool = lt j M;
+    if cond:
+     break 2
+    else:
+     break 1
+   i: int = add i one;
+   break 2
+  i_times_m: int = mul i M;
+  plus_j: int = add i_times_m j;
+  print plus_j;
+  j: int = add j one;
+}


### PR DESCRIPTION
We were getting inconsistent answers for join points because a loop back-edge was "tricking" the join point algorithm into stopping early. The fix is to just filter out back-edges using the usual algorithm of scanning the dominators.

Fixes #130 