### PR TITLE
Add purity analysis

### DIFF
--- a/src/rvsdg/egglog_optimizer/fast_analyses.rs
+++ b/src/rvsdg/egglog_optimizer/fast_analyses.rs
@@ -1,0 +1,163 @@
+use super::BRIL_OPS;
+
+fn reify_vec_rules() -> Vec<String> {
+    let mut res = vec![];
+    for (vectype, ctor, eltype) in &[
+        ("VecOperand", "VO", "Operand"),
+        ("VecVecOperand", "VVO", "VecOperand"),
+    ] {
+        // Reify vec-get to be able to be able to match on vec contents
+        res.push(format!(
+            "
+          (function {vectype}-get ({vectype} i64) {eltype})
+          (rule (({ctor} x) (> (vec-length x) 0))
+                ((union ({vectype}-get ({ctor} x) 0) (vec-get x 0)))
+                :ruleset fast-analyses)
+          (rule (({vectype}-get ({ctor} x) j)
+                 (= i (+ j 1)) (< i (vec-length x)))
+                ((union ({vectype}-get ({ctor} x) i) (vec-get x i)))
+                :ruleset fast-analyses)"
+        ));
+        // Reify vec-length
+        res.push(format!(
+            "
+            (function {vectype}-length ({vectype}) i64)
+            (rule (({ctor} x))
+                  ((set ({vectype}-length ({ctor} x)) (vec-length x)))
+                  :ruleset fast-analyses)
+        "
+        ));
+    }
+    res
+}
+
+fn is_pure_rules() -> Vec<String> {
+    let mut res: Vec<String> = vec!["
+        (relation Expr-is-pure (Expr))
+        (relation Operand-is-pure (Operand))
+        (relation Body-is-pure (Body))
+        (relation VecOperand-is-pure (VecOperand))
+        (function VecOperand-pure-prefix (VecOperand) i64 :merge (max old new))
+        (relation VecVecOperand-is-pure (VecVecOperand))
+        (function VecVecOperand-pure-prefix (VecVecOperand) i64 :merge (max old new))
+        (relation Function-is-pure (Function))
+    "
+    .into()];
+
+    // Expr-is-pure
+    res.push(
+        "
+        (rule ((= f (Const ty ops lit)))
+              ((Expr-is-pure f))
+              :ruleset fast-analyses)
+
+        (rule ((= f (Call ty name args n-outs))
+               (Function-is-pure (Func name input-types output-types body)))
+              ((Expr-is-pure f))
+              :ruleset fast-analyses)
+    "
+        .into(),
+    );
+    for bril_op in BRIL_OPS {
+        let op = bril_op.op;
+        match bril_op.input_types.as_ref() {
+            [Some(_), Some(_)] => res.push(format!(
+                "
+                (rule ((= f ({op} type e1 e2))
+                       (Operand-is-pure e1)
+                       (Operand-is-pure e2))
+                      ((Expr-is-pure f))
+                      :ruleset fast-analyses)
+                "
+            )),
+            _ => unimplemented!(),
+        };
+    }
+
+    // Operand-is-pure
+    res.push(
+        "
+        (rule ((= f (Arg x)))
+              ((Operand-is-pure f))
+              :ruleset fast-analyses)
+        (rule ((= f (Node body))
+               (Body-is-pure body))
+              ((Operand-is-pure f))
+              :ruleset fast-analyses)
+        (rule ((= f (Project i body))
+               (Body-is-pure body))
+              ((Operand-is-pure f))
+              :ruleset fast-analyses)
+    "
+        .into(),
+    );
+
+    // Body-is-pure
+    res.push(
+        "
+        (rule ((= f (PureOp e))
+               (Expr-is-pure e))
+              ((Body-is-pure f))
+              :ruleset fast-analyses)
+        (rule ((= f (Gamma pred inputs outputs))
+               (Operand-is-pure pred)
+               (VecOperand-is-pure inputs)
+               (VecVecOperand-is-pure outputs))
+              ((Body-is-pure f))
+              :ruleset fast-analyses)
+        (rule ((= f (Theta pred inputs outputs))
+               (Operand-is-pure pred)
+               (VecOperand-is-pure inputs)
+               (VecOperand-is-pure outputs))
+              ((Body-is-pure f))
+              :ruleset fast-analyses)
+        (rule ((= f (OperandGroup vec))
+               (VecOperand-is-pure vec))
+              ((Body-is-pure f))
+              :ruleset fast-analyses)
+    "
+        .into(),
+    );
+
+    // {VecOperand,VecVecOperand}-is-pure
+    for (vectype, ctor, eltype) in [
+        ("VecOperand", "VO", "Operand"),
+        ("VecVecOperand", "VVO", "VecOperand"),
+    ] {
+        res.push(format!(
+            "
+            (rule ((= f ({ctor} vec)))
+                  ((set ({vectype}-pure-prefix f) 0))
+                  :ruleset fast-analyses)
+            (rule ((= i ({vectype}-pure-prefix f))
+                   (< i ({vectype}-length f))
+                   ({eltype}-is-pure ({vectype}-get f i)))
+                  ((set ({vectype}-pure-prefix f) (+ i 1)))
+                  :ruleset fast-analyses)
+            (rule ((= ({vectype}-length f) ({vectype}-pure-prefix f)))
+                  (({vectype}-is-pure f))
+                  :ruleset fast-analyses)
+        "
+        ));
+    }
+
+    // Function-is-pure
+    res.push(
+        "
+        (rule ((= f (Func name input-types output-types body))
+               (VecOperand-is-pure body))
+              ((Function-is-pure f))
+              :ruleset fast-analyses)
+    "
+        .into(),
+    );
+
+    res
+}
+
+pub(crate) fn all_rules() -> String {
+    let mut res = vec!["(ruleset fast-analyses)".to_string()];
+    res.extend(reify_vec_rules());
+    res.extend(is_pure_rules());
+    res.join("\n")
+}

--- a/src/rvsdg/egglog_optimizer/mod.rs
+++ b/src/rvsdg/egglog_optimizer/mod.rs
@@ -3,12 +3,14 @@ use bril_rs::Type;
 use self::{constant_fold::constant_fold_egglog, reassoc::reassoc_rules, subst::subst_rules};
 
 pub(crate) mod constant_fold;
+pub(crate) mod fast_analyses;
 pub(crate) mod reassoc;
 pub(crate) mod subst;
 
 pub fn rvsdg_egglog_code() -> String {
     let code = vec![
         include_str!("schema.egg").to_string(),
+        fast_analyses::all_rules(),
         subst_rules(),
         include_str!("shift.egg").to_string(),
         include_str!("util.egg").to_string(),

--- a/src/rvsdg/egglog_optimizer/subst.rs
+++ b/src/rvsdg/egglog_optimizer/subst.rs
@@ -123,18 +123,6 @@ fn subst_beneath_rules() -> Vec<String> {
         ("VecOperand", "VO", "Operand"),
         ("VecVecOperand", "VVO", "VecOperand"),
     ] {
-        // Reify vec-get to be able to be able to match on vec contents
-        res.push(format!(
-            "
-          (function {vectype}-get ({vectype} i64) {eltype})
-          (rule (({ctor} x) (> (vec-length x) 0))
-                ((union ({vectype}-get ({ctor} x) 0) (vec-get x 0)))
-                :ruleset subst)
-          (rule (({vectype}-get ({ctor} x) j)
-                 (= i (+ j 1)) (< i (vec-length x)))
-                ((union ({vectype}-get ({ctor} x) i) (vec-get x i)))
-                :ruleset subst)"
-        ));
         // Propagate info bottom-up
         res.push(format!(
             "


### PR DESCRIPTION
Add `(relation TYPE-is-pure (TYPE))` where `TYPE` is one of `{Expr, Body, Operand, VecOperand, VecVecOperand}`.

We consider something pure if interpreting it wouldn't print anything, e.g. a function that passes around a print edge but never uses it would still be considered pure.

We also do some minor refactoring, moving vector reification into the `fast-analyses` ruleset - meant for frequently-used, at-most-linear-time analyses (e.g. this one).