### PR TITLE
Add `Body-contains-*` rules

### DIFF
--- a/src/rvsdg/egglog_optimizer/fast_analyses.rs
+++ b/src/rvsdg/egglog_optimizer/fast_analyses.rs
@@ -155,9 +155,121 @@ fn is_pure_rules() -> Vec<String> {
     res
 }
 
+// Tracks what Exprs/Operands/Bodies a body contains in its context.
+// Notably, if a Gamma/Theta contains X, then Args in X are bound by that
+// Gamma/Theta's inputs.
+fn region_contains_rules() -> Vec<String> {
+    let mut res: Vec<String> = vec!["
+        (relation Body-contains-Expr (Body Expr))
+        (relation Body-contains-Operand (Body Operand))
+        (relation Body-contains-Body (Body Body))
+    "
+    .into()];
+
+    // Bodies contain their immediate children
+    res.push(
+        "
+        (rule ((= f (PureOp e)))
+              ((Body-contains-Expr f e))
+              :ruleset fast-analyses)
+        ; A Gamma only contains its outputs
+        (rule ((= f (Gamma pred inputs outputs))
+               (= outputs-i (VecVecOperand-get outputs i))
+               (= x (VecOperand-get outputs-i j)))
+              ((Body-contains-Operand f x))
+              :ruleset fast-analyses)
+        ; A Theta contains its pred and outputs
+        (rule ((= f (Theta pred inputs outputs)))
+              ((Body-contains-Operand f pred))
+              :ruleset fast-analyses)
+        (rule ((= f (Theta pred inputs outputs))
+               (= x (VecOperand-get outputs i)))
+              ((Body-contains-Operand f x))
+              :ruleset fast-analyses)
+        (rule ((= f (OperandGroup vec))
+               (= x (VecOperand-get vec i)))
+              ((Body-contains-Operand f x))
+              :ruleset fast-analyses)
+    "
+        .into(),
+    );
+
+    // Transitivity - Body
+    res.push(
+        "
+        (rule ((Body-contains-Body f (PureOp e)))
+              ((Body-contains-Expr f e))
+              :ruleset fast-analyses)
+        ; A Gamma's pred and inputs are in the outer context
+        (rule ((Body-contains-Body f (Gamma pred inputs outputs)))
+              ((Body-contains-Operand f pred))
+              :ruleset fast-analyses)
+        (rule ((Body-contains-Body f (Gamma pred inputs outputs))
+               (= x (VecOperand-get inputs i)))
+              ((Body-contains-Operand f x))
+              :ruleset fast-analyses)
+        ; A Theta's inputs are in the outer context
+        (rule ((Body-contains-Body f (Theta pred inputs outputs))
+                (= x (VecOperand-get inputs i)))
+              ((Body-contains-Operand f x))
+              :ruleset fast-analyses)
+        (rule ((Body-contains-Body f (OperandGroup vec))
+               (= x (VecOperand-get vec i)))
+              ((Body-contains-Operand f x))
+              :ruleset fast-analyses)
+    "
+        .into(),
+    );
+
+    // Transitivity - Expr
+    res.push(
+        "
+        (rule ((Body-contains-Expr f (Call ty name args n-outs))
+               (= x (VecOperand-get args i)))
+              ((Body-contains-Operand f x))
+              :ruleset fast-analyses)
+        (rule ((Body-contains-Expr f (PRINT e1 e2)))
+              ((Body-contains-Operand f e1)
+               (Body-contains-Operand f e2))
+              :ruleset fast-analyses)
+    "
+        .into(),
+    );
+    for bril_op in BRIL_OPS {
+        let op = bril_op.op;
+        match bril_op.input_types.as_ref() {
+            [Some(_), Some(_)] => res.push(format!(
+                "
+                (rule ((Body-contains-Expr f ({op} type e1 e2)))
+                      ((Body-contains-Operand f e1)
+                       (Body-contains-Operand f e2))
+                      :ruleset fast-analyses)
+                "
+            )),
+            _ => unimplemented!(),
+        };
+    }
+
+    // Transitivity - Operand
+    res.push(
+        "
+        (rule ((Body-contains-Operand f (Node body)))
+              ((Body-contains-Body f body))
+              :ruleset fast-analyses)
+        (rule ((Body-contains-Operand f (Project i body)))
+              ((Body-contains-Body f body))
+              :ruleset fast-analyses)
+    "
+        .into(),
+    );
+
+    res
+}
+
 pub(crate) fn all_rules() -> String {
     let mut res = vec!["(ruleset fast-analyses)".to_string()];
     res.extend(reify_vec_rules());
     res.extend(is_pure_rules());
+    res.extend(region_contains_rules());
     res.join("\n")
 }

--- a/src/rvsdg/egglog_optimizer/fast_analyses.rs
+++ b/src/rvsdg/egglog_optimizer/fast_analyses.rs
@@ -206,16 +206,16 @@ fn region_contains_rules() -> Vec<String> {
               ((Body-contains-Operand f i pred))
               :ruleset fast-analyses)
         (rule ((Body-contains-Body f i (Gamma pred inputs outputs))
-               (= x (VecOperand-get inputs i)))
+               (= x (VecOperand-get inputs any)))
               ((Body-contains-Operand f i x))
               :ruleset fast-analyses)
         ; A Theta's inputs are in the outer context
         (rule ((Body-contains-Body f i (Theta pred inputs outputs))
-                (= x (VecOperand-get inputs i)))
+                (= x (VecOperand-get inputs any)))
               ((Body-contains-Operand f i x))
               :ruleset fast-analyses)
         (rule ((Body-contains-Body f i (OperandGroup vec))
-               (= x (VecOperand-get vec i)))
+               (= x (VecOperand-get vec any)))
               ((Body-contains-Operand f i x))
               :ruleset fast-analyses)
     "
@@ -226,7 +226,7 @@ fn region_contains_rules() -> Vec<String> {
     res.push(
         "
         (rule ((Body-contains-Expr f i (Call ty name args n-outs))
-               (= x (VecOperand-get args i)))
+               (= x (VecOperand-get args any)))
               ((Body-contains-Operand f i x))
               :ruleset fast-analyses)
         (rule ((Body-contains-Expr f i (PRINT e1 e2)))

--- a/src/rvsdg/tests.rs
+++ b/src/rvsdg/tests.rs
@@ -1236,7 +1236,7 @@ fn rvsdg_body_contains_operand_group() {
     (fail (check (Body-contains-Operand og any gamma-output)))
     ; Should contain Theta inputs, but not pred or outputs 
     (fail (check (Body-contains-Operand og any theta-pred)))
-    (check (Body-contains-Operand og 1 theta-input))
+    (check (Body-contains-Operand og 2 theta-input))
     (fail (check (Body-contains-Operand og any theta-output)))
     "#;
     let mut egraph = new_rvsdg_egraph();

--- a/src/rvsdg/tests.rs
+++ b/src/rvsdg/tests.rs
@@ -1137,10 +1137,11 @@ fn rvsdg_body_contains_theta() {
 
     (run-schedule (saturate fast-analyses))
 
-    (check (Body-contains-Expr theta (badd (BoolT) (Arg 7) (Arg 8))))
-    (fail (check (Body-contains-Expr theta (badd (BoolT) (Arg 1) (Arg 2)))))
-    (check (Body-contains-Operand theta (Arg 4)))
-    (fail (check (Body-contains-Body theta theta)))
+    (check (Body-contains-Expr theta -1 (badd (BoolT) (Arg 7) (Arg 8))))
+    (fail (check (Body-contains-Expr theta 0 (badd (BoolT) (Arg 7) (Arg 8)))))
+    (fail (check (Body-contains-Expr theta any (badd (BoolT) (Arg 1) (Arg 2)))))
+    (check (Body-contains-Operand theta 1 (Arg 4)))
+    (fail (check (Body-contains-Body theta any theta)))
     "#;
     let mut egraph = new_rvsdg_egraph();
     egraph.parse_and_run_program(EGGLOG_THETA_PROGRAM).unwrap();
@@ -1168,9 +1169,10 @@ fn rvsdg_body_contains_gamma() {
 
     (run-schedule (saturate fast-analyses))
 
-    (check (Body-contains-Expr gamma (badd (BoolT) (Arg 1) (Arg 0))))
-    (fail (check (Body-contains-Operand gamma (Arg 10))))
-    (fail (check (Body-contains-Operand gamma (Arg 11))))
+    (check (Body-contains-Expr gamma 0 (badd (BoolT) (Arg 1) (Arg 0))))
+    (fail (check (Body-contains-Expr gamma 1 (badd (BoolT) (Arg 1) (Arg 0)))))
+    (fail (check (Body-contains-Operand gamma any (Arg 10))))
+    (fail (check (Body-contains-Operand gamma any (Arg 11))))
     "#;
     let mut egraph = new_rvsdg_egraph();
     egraph.parse_and_run_program(EGGLOG_GAMMA_PROGRAM).unwrap();
@@ -1224,18 +1226,18 @@ fn rvsdg_body_contains_operand_group() {
 
     (run-schedule (saturate fast-analyses))
 
-    (check (Body-contains-Body og theta))
-    (check (Body-contains-Body og gamma))
-    (fail (check (Body-contains-Body og og)))
-    (check (Body-contains-Expr og (badd (BoolT) (Arg 21) (Arg 20))))
+    (check (Body-contains-Body og 2 theta))
+    (check (Body-contains-Body og 1 gamma))
+    (fail (check (Body-contains-Body og any og)))
+    (check (Body-contains-Expr og 0 (badd (BoolT) (Arg 21) (Arg 20))))
     ; Should contain Gamma pred and inputs, but not outputs
-    (check (Body-contains-Operand og gamma-pred))
-    (check (Body-contains-Operand og gamma-input))
-    (fail (check (Body-contains-Operand og gamma-output)))
+    (check (Body-contains-Operand og 1 gamma-pred))
+    (check (Body-contains-Operand og 1 gamma-input))
+    (fail (check (Body-contains-Operand og any gamma-output)))
     ; Should contain Theta inputs, but not pred or outputs 
-    (fail (check (Body-contains-Operand og theta-pred)))
-    (check (Body-contains-Operand og theta-input))
-    (fail (check (Body-contains-Operand og theta-output)))
+    (fail (check (Body-contains-Operand og any theta-pred)))
+    (check (Body-contains-Operand og 1 theta-input))
+    (fail (check (Body-contains-Operand og any theta-output)))
     "#;
     let mut egraph = new_rvsdg_egraph();
     egraph


### PR DESCRIPTION
Add `(relation Body-contains-TYPE (Body i64 TYPE))` where `TYPE` is one of `{Expr, Body, Operand}`. If we call the arguments `body`, `i`, and `e`, a tuple of one of these relations indicates that `body` contains `e` in its `i`th output.

A Body is considered to contain something if it's in the Body's context. Notably, if a Gamma/Theta contains `x`, then the Args in `x` must be bound by that Gamma/Theta.

To get the intuition:
- A region containing a Gamma will contain that Gamma's inputs and predicate.
- A region containing a Theta will contain that Theta's inputs.
- A Gamma contains its own outputs.
- A Theta contains its own predicate and outputs.

