### PR TITLE
Conditional invariant code motion

### DIFF
--- a/src/rvsdg/egglog_optimizer/conditional_invariant_code_motion.egg
+++ b/src/rvsdg/egglog_optimizer/conditional_invariant_code_motion.egg
@@ -1,0 +1,45 @@
+; If (= x (prefix-containing-operand (Gamma ...) e)), then the first x outputs
+; of Gamma contain e.
+(function prefix-containing-Operand (Body Operand) i64 :merge (max old new))
+(rule
+    ((= gamma (Gamma pred inputs outputs))
+     (Body-contains-Operand gamma 0 e))
+    ((set (prefix-containing-Operand gamma e) 0))
+    :ruleset fast-analyses)
+(rule
+    ((= gamma (Gamma pred inputs outputs))
+     (= i (prefix-containing-Operand gamma e))
+     (Body-contains-Operand gamma i e))
+    ((set (prefix-containing-Operand gamma e) (+ i 1)))
+    :ruleset fast-analyses)
+
+; Limit blowup by only repeatedly hoisting so many times
+(let max-hoists 1)
+(function hoist-count (Body) i64 :merge (max old new))
+(rule ((= gamma (Gamma pred inputs outputs)))
+      ((set (hoist-count gamma) 0))
+      :ruleset fast-analyses)
+
+; Hoist code out of a gamma, adding it as an argument instead.
+(rule 
+    ((= gamma (Gamma pred (VO inputs) outputs))
+     ; All branches contain hoist-me
+     (= (prefix-containing-Operand gamma hoist-me)
+        (VecVecOperand-length outputs))
+     (!= hoist-me (Arg any))
+     ; Can't add another version of an impure node since we might extract both.
+     ; Note: if we lift this requirement via an extraction-like substitution
+     ; procedure, then remember to add (Operand-is-pure hoist-me)!
+     (Body-is-pure gamma)
+     (= n (VecOperand-length (VO inputs)))
+     (< (hoist-count gamma) max-hoists)
+     (> (VecVecOperand-length outputs) 1))
+    ((let new-inputs
+        ; Move hoist-me into the parent context and add it as an input
+        (VO (vec-push inputs (SubstOperandAll hoist-me (VO inputs)))))
+     (let new-gamma (Gamma pred new-inputs outputs))
+     (union gamma new-gamma)
+     ; Allow the hoisted code to be replaced with the new argument
+     (can-subst-Operand-beneath (GammaCtx new-inputs) hoist-me (Arg n))
+     ; Increment hoist count
+     (set (hoist-count new-gamma) (+ 1 (hoist-count gamma)))))

--- a/src/rvsdg/egglog_optimizer/conditional_invariant_code_motion.egg
+++ b/src/rvsdg/egglog_optimizer/conditional_invariant_code_motion.egg
@@ -13,12 +13,15 @@
     ((set (prefix-containing-Operand gamma e) (+ i 1)))
     :ruleset fast-analyses)
 
-; Limit blowup by only repeatedly hoisting so many times
+; Limit blowup by only repeatedly hoisting so many times and by limiting the
+; number of branches we hoist from or max number of inputs we can add.
 (let max-hoists 1)
 (function hoist-count (Body) i64 :merge (max old new))
 (rule ((= gamma (Gamma pred inputs outputs)))
       ((set (hoist-count gamma) 0))
       :ruleset fast-analyses)
+(let max-branches 2)
+(let max-inputs 4)
 
 ; Hoist code out of a gamma, adding it as an argument instead.
 (rule 
@@ -33,6 +36,8 @@
      (Body-is-pure gamma)
      (= n (VecOperand-length (VO inputs)))
      (< (hoist-count gamma) max-hoists)
+     (<= (VecVecOperand-length outputs) max-branches)
+     (<= (+ 1 n) max-inputs)
      (> (VecVecOperand-length outputs) 1))
     ((let new-inputs
         ; Move hoist-me into the parent context and add it as an input

--- a/src/rvsdg/egglog_optimizer/mod.rs
+++ b/src/rvsdg/egglog_optimizer/mod.rs
@@ -24,6 +24,7 @@ pub fn rvsdg_egglog_code() -> String {
         include_str!("loop-optimizations.egg").to_string(),
         include_str!("interval-analysis.egg").to_string(),
         include_str!("function_inline.egg").to_string(),
+        include_str!("conditional_invariant_code_motion.egg").to_string(),
         reassoc_rules(),
         loop_invariant_detection(),
     ];
@@ -37,11 +38,16 @@ pub fn rvsdg_egglog_schedule() -> String {
     // but it helps substitutions go through since
     // they take many iterations.
 
-    "(run-schedule
+    "
+    (run-schedule
         (repeat 5 (saturate fast-analyses)
                   (run)
-                  (saturate subst)))"
-        .to_string()
+                  (saturate subst))
+        (repeat 4 subst-beneath)
+        (saturate fast-analyses)
+        (repeat 2 subst-beneath)
+    )"
+    .to_string()
 }
 
 #[derive(Debug, PartialEq, Clone)]

--- a/src/rvsdg/egglog_optimizer/mod.rs
+++ b/src/rvsdg/egglog_optimizer/mod.rs
@@ -32,16 +32,17 @@ pub fn rvsdg_egglog_code() -> String {
 }
 
 pub fn rvsdg_egglog_schedule() -> String {
-    // The current schedule runs three iterations.
-    // In-between each iteration, we saturate the subst rules.
-    // It is sound to not saturate these substitution rules,
-    // but it helps substitutions go through since
-    // they take many iterations.
-
     "(run-schedule
-        (repeat 5 (saturate fast-analyses)
-                  (run)
-                  (saturate subst))
+        ; It is sound to not saturate fast-analyses/subst, but we do because
+        ; they won't blow up and will help other rules go through.
+        (repeat 5
+            (saturate fast-analyses)
+            (run)
+            (saturate subst))
+        ; Right now, subst-beneath is inefficent (it extracts every possible
+        ; spine - we are working on this!), so we only run it a few times at the
+        ; end to apply substitutions that the main optimizations find. It's
+        ; interleaved with fast-analyses because it relies on reified vecs.
         (repeat 6 subst-beneath (saturate fast-analyses))
     )"
     .to_string()

--- a/src/rvsdg/egglog_optimizer/mod.rs
+++ b/src/rvsdg/egglog_optimizer/mod.rs
@@ -38,14 +38,11 @@ pub fn rvsdg_egglog_schedule() -> String {
     // but it helps substitutions go through since
     // they take many iterations.
 
-    "
-    (run-schedule
+    "(run-schedule
         (repeat 5 (saturate fast-analyses)
                   (run)
                   (saturate subst))
-        (repeat 4 subst-beneath)
-        (saturate fast-analyses)
-        (repeat 2 subst-beneath)
+        (repeat 6 subst-beneath (saturate fast-analyses))
     )"
     .to_string()
 }

--- a/src/rvsdg/egglog_optimizer/subst.rs
+++ b/src/rvsdg/egglog_optimizer/subst.rs
@@ -40,57 +40,57 @@ fn subst_beneath_rules() -> Vec<String> {
                (= above (ThetaCtx inputs))
                (= theta     (Theta from inputs outputs)))
               ((union theta (Theta to   inputs outputs)))
-              :ruleset subst)
+              :ruleset subst-beneath)
         (rule ((can-subst-VecOperand-beneath above from to)
                (= above (ThetaCtx inputs))
                (= theta     (Theta pred inputs from)))
               ((union theta (Theta pred inputs to)))
-              :ruleset subst)
+              :ruleset subst-beneath)
         (rule ((can-subst-Operand-beneath above pred-from pred-to)
                (can-subst-VecOperand-beneath above outputs-from outputs-to)
                (= above (ThetaCtx inputs))
                (= theta     (Theta pred-from inputs outputs-from)))
               ((union theta (Theta pred-from inputs outputs-to)))
-              :ruleset subst)
+              :ruleset subst-beneath)
         (rule ((can-subst-VecVecOperand-beneath above from to)
                (= above (GammaCtx inputs))
                (= gamma     (Gamma pred inputs from)))
               ((union gamma (Gamma pred inputs to)))
-              :ruleset subst)
+              :ruleset subst-beneath)
 
         ;; Learn can-subst-Operand-beneath
         (rule ((can-subst-Body-beneath above from to)
                (= new-from (Node from)))
               ((can-subst-Operand-beneath above new-from (Node to)))
-              :ruleset subst)
+              :ruleset subst-beneath)
         (rule ((can-subst-Body-beneath above from to)
                (= new-from (Project i from)))
               ((can-subst-Operand-beneath above new-from (Project i to)))
-              :ruleset subst)
+              :ruleset subst-beneath)
 
         ;; Learn can-subst-body-beneath
         (rule ((can-subst-Expr-beneath above from to)
                (= new-from (PureOp from)))
               ((can-subst-Body-beneath above new-from (PureOp to)))
-              :ruleset subst)
+              :ruleset subst-beneath)
         ;; Propagates up same context (Gamma: pred & inputs, Theta: inputs)
         ;; rtjoa: Is it sound to propagate up outputs if we renumber args?
         (rule ((can-subst-Operand-beneath above from to)
                (= new-from (Gamma from inputs outputs)))
               ((can-subst-Body-beneath above new-from (Gamma to inputs outputs)))
-              :ruleset subst)
+              :ruleset subst-beneath)
         (rule ((can-subst-VecOperand-beneath above from to)
                (= new-from (Gamma pred from outputs)))
               ((can-subst-Body-beneath above new-from (Gamma pred to outputs)))
-              :ruleset subst)
+              :ruleset subst-beneath)
         (rule ((can-subst-VecOperand-beneath above from to)
                (= new-from (Theta pred from outputs)))
               ((can-subst-Body-beneath above new-from (Theta pred to outputs)))
-              :ruleset subst)
+              :ruleset subst-beneath)
         (rule ((can-subst-VecOperand-beneath above from to)
                (= new-from (OperandGroup from)))
               ((can-subst-Body-beneath above new-from (OperandGroup to)))
-              :ruleset subst)
+              :ruleset subst-beneath)
         "
     .into()];
 
@@ -100,7 +100,7 @@ fn subst_beneath_rules() -> Vec<String> {
       (rule ((can-subst-VecOperand-beneath above from to)
               (= new-from (Call ty f from n-outs)))
              ((can-subst-Expr-beneath above new-from (Call ty f to n-outs)))
-            :ruleset subst)"
+            :ruleset subst-beneath)"
             .into(),
     );
     for bril_op in BRIL_OPS {
@@ -112,11 +112,11 @@ fn subst_beneath_rules() -> Vec<String> {
               (rule ((can-subst-Operand-beneath above from to)
                       (= new-from ({op} type from e2)))
                      ((can-subst-Expr-beneath above new-from ({op} type to e2)))
-                    :ruleset subst)
+                    :ruleset subst-beneath)
               (rule ((can-subst-Operand-beneath above from to)
                       (= new-from ({op} type e1 from)))
                      ((can-subst-Expr-beneath above new-from ({op} type e1 to)))
-                    :ruleset subst)
+                    :ruleset subst-beneath)
                      ",
             )),
             [Some(_), None] => res.push(format!(
@@ -145,7 +145,7 @@ fn subst_beneath_rules() -> Vec<String> {
                     above
                     ({ctor} vec)
                     ({ctor} (vec-set vec i to))))
-                :ruleset subst)"
+                :ruleset subst-beneath)"
         ));
     }
 
@@ -349,7 +349,7 @@ fn subst_all_rules() -> Vec<String> {
 }
 
 pub(crate) fn all_rules() -> String {
-    let mut res = vec!["(ruleset subst) (ruleset shift)".into()];
+    let mut res = vec!["(ruleset subst) (ruleset subst-beneath) (ruleset shift)".into()];
     res.extend(subst_beneath_rules());
     res.extend(subst_rules());
     res.extend(subst_all_rules());

--- a/src/rvsdg/tests.rs
+++ b/src/rvsdg/tests.rs
@@ -1350,7 +1350,10 @@ fn test_conditional_invariant_code_motion_2() {
     );
 }
 
+<<<<<<< HEAD
 #[test]
+=======
+>>>>>>> c16a31f (fmt)
 fn rvsdg_loop_inv_detect_simple() {
     const EGGLOG_THETA_PROGRAM1: &str = r#"
     (let t1 

--- a/src/rvsdg/tests.rs
+++ b/src/rvsdg/tests.rs
@@ -1350,10 +1350,7 @@ fn test_conditional_invariant_code_motion_2() {
     );
 }
 
-<<<<<<< HEAD
 #[test]
-=======
->>>>>>> c16a31f (fmt)
 fn rvsdg_loop_inv_detect_simple() {
     const EGGLOG_THETA_PROGRAM1: &str = r#"
     (let t1 

--- a/src/rvsdg/tests.rs
+++ b/src/rvsdg/tests.rs
@@ -1301,9 +1301,9 @@ fn test_conditional_invariant_code_motion() {
 fn test_conditional_invariant_code_motion_2() {
     const EGGLOG_GAMMA_PROGRAM: &str = r#"
     (let add
-        (Node (PureOp (badd (BoolT) (Arg 2) (Arg 3)))))
+        (Node (PureOp (badd (BoolT) (Arg 1) (Arg 2)))))
     (let gamma-inputs
-        (VO (vec-of (Arg 6) (Arg 7) (Arg 8) (Arg 9))))
+        (VO (vec-of (Arg 6) (Arg 7) (Arg 8))))
     (let gamma
         (Gamma
             (Arg 9)
@@ -1329,25 +1329,22 @@ fn test_conditional_invariant_code_motion_2() {
         (Gamma
             (Arg 9)
             (VO (vec-of
-                    (Arg 6) (Arg 7) (Arg 8) (Arg 9)
-                    (Node (PureOp (badd (BoolT) (Arg 8) (Arg 9))))))
+                    (Arg 6) (Arg 7) (Arg 8)
+                    (Node (PureOp (badd (BoolT) (Arg 7) (Arg 8))))))
             (VVO (vec-of
                 (VO (vec-of
                     (Arg 0)
-                    (Node (PureOp (bmul (BoolT) (Arg 4) (Arg 4))))))
+                    (Node (PureOp (bmul (BoolT) (Arg 3) (Arg 3))))))
                 (VO (vec-of
                     (Arg 0)
-                    (Node (PureOp (bmul (BoolT) (Arg 4) (Arg 1))))))
+                    (Node (PureOp (bmul (BoolT) (Arg 3) (Arg 1))))))
             ))
           ))
     (extract gamma)
     (check (= gamma new-gamma))
     "#;
     let mut egraph = new_rvsdg_egraph();
-    println!(
-        "{:?}",
-        egraph.parse_and_run_program(EGGLOG_GAMMA_PROGRAM).unwrap()
-    );
+    egraph.parse_and_run_program(EGGLOG_GAMMA_PROGRAM).unwrap();
 }
 
 #[test]

--- a/tests/small/branch_duplicate_work.bril
+++ b/tests/small/branch_duplicate_work.bril
@@ -1,15 +1,14 @@
-# ARGS: 1 2
-@main(x: int, y: int) {
-  zero: int = const 0;
+# ARGS: 1
+@main(x: int) {
   two: int = const 2;
-  isless: bool = lt x zero;
+  isless: bool = lt x two;
   br isless .less .greater;
 .less:
-  result: int = add x y;
+  result: int = add x x;
   jmp .done;
 .greater:
-  xy: int = add x y;
-  result: int = mul xy two;
+  double: int = add x x;
+  result: int = mul double two;
 .done:
   print result;
 }

--- a/tests/small/branch_duplicate_work.bril
+++ b/tests/small/branch_duplicate_work.bril
@@ -1,0 +1,15 @@
+# ARGS: 1 2
+@main(x: int, y: int) {
+  zero: int = const 0;
+  two: int = const 2;
+  isless: bool = lt x zero;
+  br isless .less .greater;
+.less:
+  result: int = add x y;
+  jmp .done;
+.greater:
+  xy: int = add x y;
+  result: int = mul xy two;
+.done:
+  print result;
+}

--- a/tests/snapshots/files__branch_duplicate_work-rvsdg-optimize.snap
+++ b/tests/snapshots/files__branch_duplicate_work-rvsdg-optimize.snap
@@ -1,0 +1,21 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+@main(v0: int, v1: int) {
+  v4: int = const 0;
+  v6: bool = lt v0 v4;
+  v12: int = const 2;
+  v16: int = add v0 v1;
+  br v6 .__25__ .__18__;
+.__25__:
+  v23: int = id v16;
+  jmp .__28__;
+.__18__:
+  v21: int = mul v16 v12;
+  v23: int = id v21;
+  jmp .__28__;
+.__28__:
+  print v23;
+}
+

--- a/tests/snapshots/files__branch_duplicate_work-rvsdg-optimize.snap
+++ b/tests/snapshots/files__branch_duplicate_work-rvsdg-optimize.snap
@@ -2,20 +2,19 @@
 source: tests/files.rs
 expression: visualization.result
 ---
-@main(v0: int, v1: int) {
-  v4: int = const 0;
-  v6: bool = lt v0 v4;
-  v12: int = const 2;
-  v16: int = add v0 v1;
-  br v6 .__25__ .__18__;
+@main(v0: int) {
+  v3: int = const 2;
+  v5: bool = lt v0 v3;
+  v13: int = add v0 v0;
+  br v5 .__22__ .__15__;
+.__22__:
+  v20: int = id v13;
+  jmp .__25__;
+.__15__:
+  v18: int = mul v13 v3;
+  v20: int = id v18;
+  jmp .__25__;
 .__25__:
-  v23: int = id v16;
-  jmp .__28__;
-.__18__:
-  v21: int = mul v16 v12;
-  v23: int = id v21;
-  jmp .__28__;
-.__28__:
-  print v23;
+  print v20;
 }
 

--- a/tests/snapshots/files__branch_duplicate_work-structured.snap
+++ b/tests/snapshots/files__branch_duplicate_work-structured.snap
@@ -1,0 +1,24 @@
+---
+source: tests/files.rs
+expression: visualization.result
+---
+main {
+block:
+ block:
+  block:
+   zero: int = const 0;
+   two: int = const 2;
+   isless: bool = lt x zero;
+   if isless:
+    break 2
+   else:
+    break 1
+  xy: int = add x y;
+  result: int = mul xy two;
+  break 1
+ result: int = add x y;
+block:
+ print result;
+ return
+
+}

--- a/tests/snapshots/files__branch_duplicate_work-structured.snap
+++ b/tests/snapshots/files__branch_duplicate_work-structured.snap
@@ -6,17 +6,16 @@ main {
 block:
  block:
   block:
-   zero: int = const 0;
    two: int = const 2;
-   isless: bool = lt x zero;
+   isless: bool = lt x two;
    if isless:
     break 2
    else:
     break 1
-  xy: int = add x y;
-  result: int = mul xy two;
+  double: int = add x x;
+  result: int = mul double two;
   break 1
- result: int = add x y;
+ result: int = add x x;
 block:
  print result;
  return


### PR DESCRIPTION
## Summary

If all branches of a `Gamma` share code, we can compute it outside the body and pass the result via a new argument.

Example:
| Unoptimized  | Optimized |
| ------------- | ------------- |
| ![image](https://github.com/oflatt/eggcc/assets/51928404/b3b3da69-2b86-411a-b8f4-da3cde6dda15) | ![image](https://github.com/oflatt/eggcc/assets/51928404/171d75a2-7048-441d-a982-cb0e59d11f77) |

As this uses `can-subst-beneath`, which is slow/doesn't saturate, we move it to its own ruleset, `subst-beneath`, and modify the schedule to use it more sparingly. In the future we hope to improve `can-subst-beneath` (contextual equality, named wires), separately from this PR.

## Testing
Added Bril test at `tests/small/branch_duplicate_work.bril` and RVSDG-level tests at `src/rvsdg/tests.rs`.