### PR TITLE
Optimize passed through arguments, but only in the pure case

### DIFF
--- a/src/rvsdg/egglog_optimizer/interval-analysis.egg
+++ b/src/rvsdg/egglog_optimizer/interval-analysis.egg
@@ -37,11 +37,11 @@
 
 ; Rules that union intervals for a gamma
 (rule (
-        (= lhs (Project i (Gamma pred ins (VVO outs))))
-        (= (VO thens) (vec-get outs 1))
-        (= (VO elses) (vec-get outs 0))
-        (= thenival (ival (vec-get thens i)))
-        (= elseival (ival (vec-get elses i)))
+        (= lhs (Project i (Gamma pred ins outs)))
+        (= thens (VecVecOperand-get outs 1))
+        (= elses (VecVecOperand-get outs 0))
+        (= thenival (ival (VecOperand-get thens i)))
+        (= elseival (ival (VecOperand-get elses i)))
       )
       (
         (set (ival lhs) (interval-union thenival elseival))
@@ -49,12 +49,12 @@
       :ruleset fast-analyses
 )
 (rule (
-        (= gamma (Gamma pred ins (VVO outs)))
+        (= gamma (Gamma pred ins outs))
         (= lhs (Project i gamma))
-        (= (VO thens) (vec-get outs 1))
-        (= (VO elses) (vec-get outs 0))
-        (= thenival (context-ival (vec-get thens i) gamma))
-        (= elseival (context-ival (vec-get elses i) gamma))
+        (= thens (VecVecOperand-get outs 1))
+        (= elses (VecVecOperand-get outs 0))
+        (= thenival (context-ival (VecOperand-get thens i) gamma))
+        (= elseival (context-ival (VecOperand-get elses i) gamma))
       )
       (
         (set (ival lhs) (interval-union thenival elseival))

--- a/src/rvsdg/egglog_optimizer/loop-optimizations.egg
+++ b/src/rvsdg/egglog_optimizer/loop-optimizations.egg
@@ -8,7 +8,7 @@
        (let pass-through (PassThroughArguments (vec-length outputs)))
        (union theta
           (Gamma
-            (SubstOperandAll pred after-one-iter)
+            (SubstOperandAll pred (VO inputs))
             after-one-iter
             (VVO
               (vec-of

--- a/src/rvsdg/egglog_optimizer/mod.rs
+++ b/src/rvsdg/egglog_optimizer/mod.rs
@@ -1,9 +1,13 @@
 use bril_rs::Type;
 
-use self::{constant_fold::constant_fold_egglog, reassoc::reassoc_rules};
+use self::{
+    constant_fold::constant_fold_egglog, passthrough_optimize::passthrough_optimize_rules,
+    reassoc::reassoc_rules,
+};
 
 pub(crate) mod constant_fold;
 pub(crate) mod fast_analyses;
+pub(crate) mod passthrough_optimize;
 pub(crate) mod reassoc;
 pub(crate) mod subst;
 
@@ -15,6 +19,7 @@ pub fn rvsdg_egglog_code() -> String {
         include_str!("util.egg").to_string(),
         constant_fold_egglog(),
         include_str!("gamma_rewrites.egg").to_string(),
+        passthrough_optimize_rules(),
         include_str!("loop-optimizations.egg").to_string(),
         include_str!("interval-analysis.egg").to_string(),
         include_str!("function_inline.egg").to_string(),

--- a/src/rvsdg/egglog_optimizer/passthrough_optimize.rs
+++ b/src/rvsdg/egglog_optimizer/passthrough_optimize.rs
@@ -14,7 +14,9 @@ pub(crate) fn passthrough_optimize_rules() -> String {
        (= passed-through (VecOperand-get inputs index))
        (Body-is-pure loop)
       )
-      ((union lhs passed-through))
+      ((union lhs passed-through)
+       ;; also subsume the project
+       (delete (Project index loop)))
       :ruleset {ruleset})
 
 ;; If a gamma passes along an argument in both branches,
@@ -29,7 +31,9 @@ pub(crate) fn passthrough_optimize_rules() -> String {
        (= (VecOperand-get outputs0 index) (Arg index))
        (= (VecOperand-get outputs1 index) (Arg index))
        (= passed-through (VecOperand-get inputs index)))
-      ((union lhs passed-through))
+      ((union lhs passed-through)
+       ;; also subsume the project
+       (delete (Project index loop)))
       :ruleset {ruleset})
         "
     ));

--- a/src/rvsdg/egglog_optimizer/passthrough_optimize.rs
+++ b/src/rvsdg/egglog_optimizer/passthrough_optimize.rs
@@ -9,16 +9,17 @@ pub(crate) fn passthrough_optimize_rules() -> String {
 ;; can union with the inputs.
 ;; BUT only if the theta is pure!
 (rule ((= lhs (Project index loop))
-        (= loop (Theta pred inputs outputs))
-        (= (VecOperand-get outputs index) (Arg index))
-        (= input (VecOperand-get inputs index))
-        (Body-is-pure loop)
+       (= loop (Theta pred inputs outputs))
+       (= (VecOperand-get outputs index) (Arg index))
+       (= passed-through (VecOperand-get inputs index))
+       (Body-is-pure loop)
       )
-      ((union lhs input))
+      ((union lhs passed-through))
       :ruleset {ruleset})
 
 ;; If a gamma passes along an argument in both branches,
-;; extract the input instead.
+;; union project with input
+;; BUT only if the gamma is pure!
 (rule ((= lhs (Project index loop))
        (= loop (Gamma pred inputs outputs))
        (= outputs (VVO outputs-inner))
@@ -27,8 +28,8 @@ pub(crate) fn passthrough_optimize_rules() -> String {
        (= outputs1 (VecVecOperand-get outputs 1))
        (= (VecOperand-get outputs0 index) (Arg index))
        (= (VecOperand-get outputs1 index) (Arg index))
-       (= passedthrough (ExtractedOperand (VecOperand-get inputs index))))
-      ((set (ExtractedOperand lhs) passedthrough))
+       (= passed-through (VecOperand-get inputs index)))
+      ((union lhs passed-through))
       :ruleset {ruleset})
         "
     ));

--- a/src/rvsdg/egglog_optimizer/passthrough_optimize.rs
+++ b/src/rvsdg/egglog_optimizer/passthrough_optimize.rs
@@ -1,0 +1,37 @@
+pub(crate) fn passthrough_optimize_rules() -> String {
+    let ruleset = "fast-analyses";
+    let mut res = vec![];
+
+    res.push(format!(
+        "
+
+;; If a theta passes along argument,
+;; can union with the inputs.
+;; BUT only if the theta is pure!
+(rule ((= lhs (Project index loop))
+        (= loop (Theta pred inputs outputs))
+        (= (VecOperand-get outputs index) (Arg index))
+        (= input (VecOperand-get inputs index))
+        (Body-is-pure loop)
+      )
+      ((union lhs input))
+      :ruleset {ruleset})
+
+;; If a gamma passes along an argument in both branches,
+;; extract the input instead.
+(rule ((= lhs (Project index loop))
+       (= loop (Gamma pred inputs outputs))
+       (= outputs (VVO outputs-inner))
+       (= 2 (vec-length outputs-inner))
+       (= outputs0 (VecVecOperand-get outputs 0))
+       (= outputs1 (VecVecOperand-get outputs 1))
+       (= (VecOperand-get outputs0 index) (Arg index))
+       (= (VecOperand-get outputs1 index) (Arg index))
+       (= passedthrough (ExtractedOperand (VecOperand-get inputs index))))
+      ((set (ExtractedOperand lhs) passedthrough))
+      :ruleset {ruleset})
+        "
+    ));
+
+    res.join("\n").to_string()
+}

--- a/tests/snapshots/files__block-diamond-rvsdg-optimize.snap
+++ b/tests/snapshots/files__block-diamond-rvsdg-optimize.snap
@@ -10,42 +10,42 @@ expression: visualization.result
   br v5 .__29__ .__15__;
 .__85__:
   v82: int = id v24;
-  v83: int = id v25;
+  v83: int = id v11;
   jmp .__89__;
 .__76__:
-  v79: int = add v24 v26;
+  v79: int = add v24 v3;
   v82: int = id v79;
-  v83: int = id v25;
+  v83: int = id v11;
   jmp .__89__;
 .__68__:
   v69: int = const 1;
   v70: bool = eq v27 v69;
   br v70 .__85__ .__76__;
-.__62__:
-  v24: int = id v47;
-  v25: int = id v48;
-  v26: int = id v49;
-  v27: int = id v50;
+.__63__:
+  v24: int = id v48;
+  v25: int = id v11;
+  v26: int = id v3;
+  v27: int = id v51;
   jmp .__68__;
-.__52__:
-  v55: int = add v37 v3;
-  v59: int = const 1;
-  v47: int = id v55;
-  v48: int = id v11;
-  v49: int = id v3;
-  v50: int = id v59;
-  jmp .__62__;
-.__41__:
-  v45: int = const 0;
-  v47: int = id v37;
-  v48: int = id v11;
-  v49: int = id v3;
-  v50: int = id v45;
-  jmp .__62__;
+.__53__:
+  v56: int = add v38 v3;
+  v60: int = const 1;
+  v48: int = id v56;
+  v49: int = id v11;
+  v50: int = id v3;
+  v51: int = id v60;
+  jmp .__63__;
+.__42__:
+  v46: int = const 0;
+  v48: int = id v38;
+  v49: int = id v11;
+  v50: int = id v3;
+  v51: int = id v46;
+  jmp .__63__;
 .__29__:
-  v31: bool = lt v3 v0;
-  v37: int = add v9 v3;
-  br v31 .__52__ .__41__;
+  v32: bool = lt v3 v0;
+  v38: int = add v9 v3;
+  br v32 .__53__ .__42__;
 .__15__:
   v18: int = add v9 v11;
   v22: int = const 0;
@@ -55,7 +55,7 @@ expression: visualization.result
   v27: int = id v22;
   jmp .__68__;
 .__89__:
-  v91: int = add v82 v83;
+  v91: int = add v82 v11;
   print v91;
 }
 

--- a/tests/snapshots/files__collatz-rvsdg-optimize.snap
+++ b/tests/snapshots/files__collatz-rvsdg-optimize.snap
@@ -14,67 +14,67 @@ expression: visualization.result
   v17: int = id v9;
   v18: int = id v11;
   jmp .__20__;
-.__115__:
+.__117__:
   v123: int = const 1;
-  v124: bool = eq v98 v123;
-  v13: int = id v97;
-  v14: int = id v99;
-  v15: int = id v100;
-  v16: int = id v101;
-  v17: int = id v102;
-  v18: int = id v103;
+  v124: bool = eq v100 v123;
+  v13: int = id v13;
+  v14: int = id v101;
+  v15: int = id v102;
+  v16: int = id v103;
+  v17: int = id v104;
+  v18: int = id v105;
   br v124 .__20__ .__127__;
-.__105__:
-  v107: int = const 0;
-  v97: int = id v13;
-  v98: int = id v107;
-  v99: int = id v14;
-  v100: int = id v15;
-  v101: int = id v16;
-  v102: int = id v17;
-  v103: int = id v18;
-  jmp .__115__;
-.__89__:
-  v97: int = id v68;
-  v98: int = id v69;
-  v99: int = id v70;
-  v100: int = id v71;
-  v101: int = id v72;
-  v102: int = id v73;
-  v103: int = id v74;
-  jmp .__115__;
-.__76__:
-  v78: int = const 1;
-  v82: int = div v14 v15;
-  v68: int = id v13;
-  v69: int = id v78;
-  v70: int = id v82;
-  v71: int = id v15;
-  v72: int = id v16;
-  v73: int = id v17;
-  v74: int = id v18;
-  jmp .__89__;
-.__53__:
-  v55: int = const 1;
-  v60: int = mul v17 v14;
-  v62: int = add v16 v60;
-  v68: int = id v13;
-  v69: int = id v55;
-  v70: int = id v62;
-  v71: int = id v15;
-  v72: int = id v16;
-  v73: int = id v17;
-  v74: int = id v18;
-  jmp .__89__;
-.__32__:
-  v35: int = div v14 v15;
-  v38: int = mul v35 v15;
-  v40: int = sub v14 v38;
-  v43: bool = eq v40 v18;
-  br v43 .__76__ .__53__;
+.__107__:
+  v109: int = const 0;
+  v99: int = id v13;
+  v100: int = id v109;
+  v101: int = id v14;
+  v102: int = id v15;
+  v103: int = id v16;
+  v104: int = id v17;
+  v105: int = id v18;
+  jmp .__117__;
+.__93__:
+  v99: int = id v13;
+  v100: int = id v73;
+  v101: int = id v74;
+  v102: int = id v75;
+  v103: int = id v76;
+  v104: int = id v77;
+  v105: int = id v78;
+  jmp .__117__;
+.__80__:
+  v82: int = const 1;
+  v86: int = div v14 v15;
+  v72: int = id v13;
+  v73: int = id v82;
+  v74: int = id v86;
+  v75: int = id v15;
+  v76: int = id v16;
+  v77: int = id v17;
+  v78: int = id v18;
+  jmp .__93__;
+.__57__:
+  v59: int = const 1;
+  v64: int = mul v17 v14;
+  v66: int = add v16 v64;
+  v72: int = id v13;
+  v73: int = id v59;
+  v74: int = id v66;
+  v75: int = id v15;
+  v76: int = id v16;
+  v77: int = id v17;
+  v78: int = id v18;
+  jmp .__93__;
+.__34__:
+  v39: int = div v14 v15;
+  v42: int = mul v39 v15;
+  v44: int = sub v14 v42;
+  v47: bool = eq v44 v18;
+  br v47 .__80__ .__57__;
 .__20__:
-  v22: bool = eq v14 v16;
-  br v22 .__105__ .__32__;
+  v24: bool = eq v14 v16;
+  br v24 .__107__ .__34__;
 .__127__:
   print v13;
 }

--- a/tests/snapshots/files__eliminate_gamma_interval-rvsdg-optimize.snap
+++ b/tests/snapshots/files__eliminate_gamma_interval-rvsdg-optimize.snap
@@ -4,23 +4,6 @@ expression: visualization.result
 ---
 @main(v0: int) {
   v2: int = const 2;
-  v5: int = const 10;
-  v7: bool = lt v0 v5;
-  v11: int = const 5;
-  br v7 .__23__ .__13__;
-.__23__:
-  v24: int = const 2;
-  v27: int = add v24 v11;
-  v20: int = id v27;
-  v21: int = id v11;
-  jmp .__31__;
-.__13__:
-  v14: int = const 3;
-  v17: int = add v14 v11;
-  v20: int = id v17;
-  v21: int = id v11;
-  jmp .__31__;
-.__31__:
   print v2;
 }
 

--- a/tests/snapshots/files__fib_shape-rvsdg-optimize.snap
+++ b/tests/snapshots/files__fib_shape-rvsdg-optimize.snap
@@ -9,31 +9,31 @@ expression: visualization.result
   v9: int = id v5;
   v10: int = id v0;
   jmp .__12__;
-.__42__:
+.__43__:
   v47: int = const 1;
-  v48: bool = eq v28 v47;
-  v8: int = id v27;
-  v9: int = id v29;
-  v10: int = id v30;
+  v48: bool = eq v29 v47;
+  v8: int = id v28;
+  v9: int = id v30;
+  v10: int = id v31;
   br v48 .__12__ .__51__;
-.__32__:
-  v35: int = add v8 v9;
-  v37: int = const 1;
-  v27: int = id v35;
-  v28: int = id v37;
-  v29: int = id v9;
-  v30: int = id v10;
-  jmp .__42__;
-.__21__:
-  v23: int = const 0;
-  v27: int = id v8;
-  v28: int = id v23;
-  v29: int = id v9;
-  v30: int = id v10;
-  jmp .__42__;
+.__33__:
+  v36: int = add v8 v9;
+  v38: int = const 1;
+  v28: int = id v36;
+  v29: int = id v38;
+  v30: int = id v9;
+  v31: int = id v10;
+  jmp .__43__;
+.__22__:
+  v24: int = const 0;
+  v28: int = id v8;
+  v29: int = id v24;
+  v30: int = id v9;
+  v31: int = id v10;
+  jmp .__43__;
 .__12__:
-  v14: bool = lt v8 v10;
-  br v14 .__32__ .__21__;
+  v15: bool = lt v8 v10;
+  br v15 .__33__ .__22__;
 .__51__:
   print v8;
 }

--- a/tests/snapshots/files__flatten_loop-rvsdg-optimize.snap
+++ b/tests/snapshots/files__flatten_loop-rvsdg-optimize.snap
@@ -30,8 +30,8 @@ expression: visualization.result
 .__97__:
   v104: int = const 1;
   v105: bool = eq v72 v104;
-  v45: int = id v70;
-  v46: int = id v71;
+  v45: int = id v45;
+  v46: int = id v46;
   v47: int = id v73;
   v48: int = id v74;
   v49: int = id v75;

--- a/tests/snapshots/files__gamma_condition_and-rvsdg-optimize.snap
+++ b/tests/snapshots/files__gamma_condition_and-rvsdg-optimize.snap
@@ -3,21 +3,21 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main(v0: int) {
-  v3: int = const 2;
-  v5: bool = lt v0 v3;
-  v7: bool = const true;
-  v9: bool = and v5 v7;
-  v13: int = const 3;
-  br v9 .__23__ .__17__;
-.__23__:
+  v2: int = const 3;
+  v5: int = const 2;
+  v7: bool = lt v0 v5;
+  v9: bool = const true;
+  v11: bool = and v7 v9;
+  br v11 .__24__ .__18__;
+.__24__:
   print v0;
-  v21: int = id v13;
-  jmp .__28__;
-.__17__:
-  print v3;
-  v21: int = id v13;
-  jmp .__28__;
-.__28__:
-  print v21;
+  v22: int = id v2;
+  jmp .__29__;
+.__18__:
+  print v5;
+  v22: int = id v2;
+  jmp .__29__;
+.__29__:
+  print v2;
 }
 

--- a/tests/snapshots/files__implicit-return-rvsdg-optimize.snap
+++ b/tests/snapshots/files__implicit-return-rvsdg-optimize.snap
@@ -3,9 +3,47 @@ source: tests/files.rs
 expression: visualization.result
 ---
 @main {
-  v1: int = const 4;
-  v3: int = const 15;
-  call @pow v1 v3;
+  v2: int = const 4;
+  v4: int = const 0;
+  v7: int = const 15;
+  v9: int = id v2;
+  v10: int = id v4;
+  v11: int = id v2;
+  v12: int = id v7;
+  jmp .__14__;
+.__56__:
+  v61: int = const 1;
+  v62: bool = eq v37 v61;
+  v9: int = id v36;
+  v10: int = id v38;
+  v11: int = id v39;
+  v12: int = id v40;
+  br v62 .__14__ .__65__;
+.__42__:
+  v45: int = mul v9 v11;
+  v47: int = const 1;
+  v51: int = add v47 v10;
+  v36: int = id v45;
+  v37: int = id v47;
+  v38: int = id v51;
+  v39: int = id v11;
+  v40: int = id v12;
+  jmp .__56__;
+.__29__:
+  v31: int = const 0;
+  v36: int = id v9;
+  v37: int = id v31;
+  v38: int = id v10;
+  v39: int = id v11;
+  v40: int = id v12;
+  jmp .__56__;
+.__14__:
+  v17: int = const 1;
+  v19: int = sub v12 v17;
+  v21: bool = lt v10 v19;
+  br v21 .__42__ .__29__;
+.__65__:
+  print v9;
 }
 @pow(v0: int, v1: int) {
   v5: int = const 0;
@@ -14,37 +52,37 @@ expression: visualization.result
   v11: int = id v0;
   v12: int = id v1;
   jmp .__14__;
-.__55__:
+.__56__:
   v61: int = const 1;
-  v62: bool = eq v36 v61;
-  v9: int = id v35;
-  v10: int = id v37;
-  v11: int = id v38;
-  v12: int = id v39;
+  v62: bool = eq v37 v61;
+  v9: int = id v36;
+  v10: int = id v38;
+  v11: int = id v39;
+  v12: int = id v40;
   br v62 .__14__ .__65__;
-.__41__:
-  v44: int = mul v9 v11;
-  v46: int = const 1;
-  v50: int = add v46 v10;
-  v35: int = id v44;
-  v36: int = id v46;
-  v37: int = id v50;
-  v38: int = id v11;
-  v39: int = id v12;
-  jmp .__55__;
-.__28__:
-  v30: int = const 0;
-  v35: int = id v9;
-  v36: int = id v30;
-  v37: int = id v10;
-  v38: int = id v11;
-  v39: int = id v12;
-  jmp .__55__;
+.__42__:
+  v45: int = mul v9 v11;
+  v47: int = const 1;
+  v51: int = add v47 v10;
+  v36: int = id v45;
+  v37: int = id v47;
+  v38: int = id v51;
+  v39: int = id v11;
+  v40: int = id v12;
+  jmp .__56__;
+.__29__:
+  v31: int = const 0;
+  v36: int = id v9;
+  v37: int = id v31;
+  v38: int = id v10;
+  v39: int = id v11;
+  v40: int = id v12;
+  jmp .__56__;
 .__14__:
-  v16: int = const 1;
-  v18: int = sub v12 v16;
-  v20: bool = lt v10 v18;
-  br v20 .__41__ .__28__;
+  v17: int = const 1;
+  v19: int = sub v12 v17;
+  v21: bool = lt v10 v19;
+  br v21 .__42__ .__29__;
 .__65__:
   print v9;
 }


### PR DESCRIPTION
This PR is blocked on subst rules not saturating when there is a cycle.

It also relies on the argument that unioning a project with something else is valid when the whole thing is pure.
The non-pure version is much harder.