### PR TITLE
Add print rules to can-subst-beneath

### DIFF
--- a/src/rvsdg/egglog_optimizer/subst.rs
+++ b/src/rvsdg/egglog_optimizer/subst.rs
@@ -148,6 +148,15 @@ fn subst_beneath_rules() -> Vec<String> {
                 :ruleset subst-beneath)"
         ));
     }
+ 
+    res.push(
+        "
+        (rule ((can-subst-Operand-beneath above from to)
+               (= new-from (PRINT from state)))
+               ((can-subst-Expr-beneath above new-from (PRINT to state)))
+               :ruleset subst)
+        ".into()
+    );
 
     res
 }

--- a/src/rvsdg/egglog_optimizer/subst.rs
+++ b/src/rvsdg/egglog_optimizer/subst.rs
@@ -154,7 +154,7 @@ fn subst_beneath_rules() -> Vec<String> {
         (rule ((can-subst-Operand-beneath above from to)
                (= new-from (PRINT from state)))
                ((can-subst-Expr-beneath above new-from (PRINT to state)))
-               :ruleset subst)
+               :ruleset subst-beneath)
         (rule ((can-subst-Operand-beneath above from to)
                (= new-from (PRINT op from)))
                ((can-subst-Expr-beneath above new-from (PRINT op to)))

--- a/src/rvsdg/egglog_optimizer/subst.rs
+++ b/src/rvsdg/egglog_optimizer/subst.rs
@@ -155,6 +155,10 @@ fn subst_beneath_rules() -> Vec<String> {
                (= new-from (PRINT from state)))
                ((can-subst-Expr-beneath above new-from (PRINT to state)))
                :ruleset subst)
+        (rule ((can-subst-Operand-beneath above from to)
+               (= new-from (PRINT op from)))
+               ((can-subst-Expr-beneath above new-from (PRINT op to)))
+               :ruleset subst-beneath)
         ".into()
     );
 

--- a/src/rvsdg/egglog_optimizer/subst.rs
+++ b/src/rvsdg/egglog_optimizer/subst.rs
@@ -148,7 +148,7 @@ fn subst_beneath_rules() -> Vec<String> {
                 :ruleset subst-beneath)"
         ));
     }
- 
+
     res.push(
         "
         (rule ((can-subst-Operand-beneath above from to)
@@ -158,8 +158,8 @@ fn subst_beneath_rules() -> Vec<String> {
         (rule ((can-subst-Operand-beneath above from to)
                (= new-from (PRINT op from)))
                ((can-subst-Expr-beneath above new-from (PRINT op to)))
-               :ruleset subst-beneath)
-        ".into()
+               :ruleset subst-beneath)"
+            .into(),
     );
 
     res


### PR DESCRIPTION
`can-subst-*-beneath` would get stopped by a PRINT because there was no rule to propagate it through a print.