### PR TITLE
Optimize `can-subst-beneath` by checking whether `new-from` is in `above` before creating new tuple

### DIFF
--- a/src/rvsdg/egglog_optimizer/mod.rs
+++ b/src/rvsdg/egglog_optimizer/mod.rs
@@ -43,7 +43,7 @@ pub fn rvsdg_egglog_schedule() -> String {
         ; spine - we are working on this!), so we only run it a few times at the
         ; end to apply substitutions that the main optimizations find. It's
         ; interleaved with fast-analyses because it relies on reified vecs.
-        (repeat 6 subst-beneath (saturate fast-analyses))
+        (repeat 10 subst-beneath (saturate fast-analyses))
     )"
     .to_string()
 }

--- a/src/rvsdg/egglog_optimizer/subst.rs
+++ b/src/rvsdg/egglog_optimizer/subst.rs
@@ -29,6 +29,12 @@ fn subst_beneath_rules() -> Vec<String> {
             (GammaCtx VecOperand)
             (ThetaCtx VecOperand))
 
+        (relation creates-context (Body Context))
+        (rule ((= gamma (Gamma pred inputs outputs)))
+              ((creates-context gamma (GammaCtx inputs))) :ruleset fast-analyses)
+        (rule ((= theta (Theta pred inputs outputs)))
+              ((creates-context theta (ThetaCtx inputs))) :ruleset fast-analyses)
+
         (relation can-subst-Expr-beneath (Context Expr Expr))
         (relation can-subst-Operand-beneath (Context Operand Operand))
         (relation can-subst-Body-beneath (Context Body Body))
@@ -60,35 +66,49 @@ fn subst_beneath_rules() -> Vec<String> {
 
         ;; Learn can-subst-Operand-beneath
         (rule ((can-subst-Body-beneath above from to)
-               (= new-from (Node from)))
+               (= new-from (Node from))
+               (creates-context body above)
+               (Body-contains-Operand body ignore-i new-from))
               ((can-subst-Operand-beneath above new-from (Node to)))
               :ruleset subst-beneath)
         (rule ((can-subst-Body-beneath above from to)
-               (= new-from (Project i from)))
+               (= new-from (Project i from))
+               (creates-context body above)
+               (Body-contains-Operand body ignore-i new-from))
               ((can-subst-Operand-beneath above new-from (Project i to)))
               :ruleset subst-beneath)
 
         ;; Learn can-subst-body-beneath
         (rule ((can-subst-Expr-beneath above from to)
-               (= new-from (PureOp from)))
+               (= new-from (PureOp from))
+               (creates-context body above)
+               (Body-contains-Body body ignore-i new-from))
               ((can-subst-Body-beneath above new-from (PureOp to)))
               :ruleset subst-beneath)
         ;; Propagates up same context (Gamma: pred & inputs, Theta: inputs)
         ;; rtjoa: Is it sound to propagate up outputs if we renumber args?
         (rule ((can-subst-Operand-beneath above from to)
-               (= new-from (Gamma from inputs outputs)))
+               (= new-from (Gamma from inputs outputs))
+               (creates-context body above)
+               (Body-contains-Body body ignore-i new-from))
               ((can-subst-Body-beneath above new-from (Gamma to inputs outputs)))
               :ruleset subst-beneath)
         (rule ((can-subst-VecOperand-beneath above from to)
-               (= new-from (Gamma pred from outputs)))
+               (= new-from (Gamma pred from outputs))
+               (creates-context body above)
+               (Body-contains-Body body ignore-i new-from))
               ((can-subst-Body-beneath above new-from (Gamma pred to outputs)))
               :ruleset subst-beneath)
         (rule ((can-subst-VecOperand-beneath above from to)
-               (= new-from (Theta pred from outputs)))
+               (= new-from (Theta pred from outputs))
+               (creates-context body above)
+               (Body-contains-Body body ignore-i new-from))
               ((can-subst-Body-beneath above new-from (Theta pred to outputs)))
               :ruleset subst-beneath)
         (rule ((can-subst-VecOperand-beneath above from to)
-               (= new-from (OperandGroup from)))
+               (= new-from (OperandGroup from))
+               (creates-context body above)
+               (Body-contains-Body body ignore-i new-from))
               ((can-subst-Body-beneath above new-from (OperandGroup to)))
               :ruleset subst-beneath)
         "
@@ -98,7 +118,9 @@ fn subst_beneath_rules() -> Vec<String> {
     res.push(
         "
       (rule ((can-subst-VecOperand-beneath above from to)
-              (= new-from (Call ty f from n-outs)))
+              (= new-from (Call ty f from n-outs))
+              (creates-context body above)
+              (Body-contains-Expr body ignore-i new-from))
              ((can-subst-Expr-beneath above new-from (Call ty f to n-outs)))
             :ruleset subst-beneath)"
             .into(),
@@ -110,19 +132,32 @@ fn subst_beneath_rules() -> Vec<String> {
             [Some(_), Some(_)] => res.push(format!(
                 "
               (rule ((can-subst-Operand-beneath above from to)
-                      (= new-from ({op} type from e2)))
+                      (= new-from ({op} type from e2))
+                      (creates-context body above)
+                      (Body-contains-Expr body ignore-i new-from))
                      ((can-subst-Expr-beneath above new-from ({op} type to e2)))
                     :ruleset subst-beneath)
               (rule ((can-subst-Operand-beneath above from to)
-                      (= new-from ({op} type e1 from)))
+                      (= new-from ({op} type e1 from))
+                      (creates-context body above)
+                      (Body-contains-Expr body ignore-i new-from))
                      ((can-subst-Expr-beneath above new-from ({op} type e1 to)))
+                    :ruleset subst-beneath)
+              (rule ((can-subst-Operand-beneath above from1 to1)
+                     (can-subst-Operand-beneath above from2 to2)
+                      (= new-from ({op} type from1 from2))
+                      (creates-context body above)
+                      (Body-contains-Expr body ignore-i new-from))
+                     ((can-subst-Expr-beneath above new-from ({op} type to1 to2)))
                     :ruleset subst-beneath)
                      ",
             )),
             [Some(_), None] => res.push(format!(
                 "
               (rule ((can-subst-Operand-beneath above from to)
-                      (= new-from ({op} type from)))
+                      (= new-from ({op} type from))
+                      (creates-context body above)
+                      (Body-contains-Expr body ignore-i new-from))
                      ((can-subst-Expr-beneath above new-from ({op} type to)))
                     :ruleset subst)
                 ",
@@ -130,7 +165,22 @@ fn subst_beneath_rules() -> Vec<String> {
             _ => unimplemented!(),
         };
     }
-
+    res.push(
+        "
+        (rule ((can-subst-Operand-beneath above from to)
+               (= new-from (PRINT from state))
+               (creates-context body above)
+               (Body-contains-Expr body ignore-i new-from))
+              ((can-subst-Expr-beneath above new-from (PRINT to state)))
+              :ruleset subst-beneath)
+        (rule ((can-subst-Operand-beneath above from to)
+               (= new-from (PRINT op from))
+               (creates-context body above)
+               (Body-contains-Expr body ignore-i new-from))
+              ((can-subst-Expr-beneath above new-from (PRINT op to)))
+              :ruleset subst-beneath)"
+            .into(),
+    );
     // Learn can-subst-{VecOperand, VecVecOperand}-beneath
     for (vectype, ctor, eltype) in &[
         ("VecOperand", "VO", "Operand"),
@@ -148,19 +198,6 @@ fn subst_beneath_rules() -> Vec<String> {
                 :ruleset subst-beneath)"
         ));
     }
-
-    res.push(
-        "
-        (rule ((can-subst-Operand-beneath above from to)
-               (= new-from (PRINT from state)))
-               ((can-subst-Expr-beneath above new-from (PRINT to state)))
-               :ruleset subst-beneath)
-        (rule ((can-subst-Operand-beneath above from to)
-               (= new-from (PRINT op from)))
-               ((can-subst-Expr-beneath above new-from (PRINT op to)))
-               :ruleset subst-beneath)"
-            .into(),
-    );
 
     res
 }

--- a/src/rvsdg/tests.rs
+++ b/src/rvsdg/tests.rs
@@ -1321,7 +1321,7 @@ fn test_conditional_invariant_code_motion_2() {
     (run-schedule
         (saturate fast-analyses)
         (run)
-        (saturate subst)
+        (saturate subst fast-analyses)
         (repeat 3 (repeat 5 subst-beneath) (saturate fast-analyses))
     )
     


### PR DESCRIPTION
Before, 20 iterations of `subst-beneath` OOM'd after 15min on my computer. With this change, it takes ~30 seconds.

We conservatively increase the number of iters from 6 to 10.

Thanks to @yihozhang for originally suggesting this optimization!